### PR TITLE
fixed a bug where phoneDialInInformation would not deserialize properly

### DIFF
--- a/UCWASDK/UCWASDK/Models/PhoneDialInInformation.cs
+++ b/UCWASDK/UCWASDK/Models/PhoneDialInInformation.cs
@@ -35,12 +35,12 @@ namespace Microsoft.Skype.UCWA.Models
         internal InternalEmbedded Embedded { get; set; }
 
         [JsonIgnore]
-        public DialInRegion DialInRegion { get { return Embedded.dialInRegion; } }
+        public DialInRegion[] DialInRegion { get { return Embedded.dialInRegion; } }
 
         internal class InternalEmbedded
         {
             [JsonProperty("dialInRegion")]
-            internal DialInRegion dialInRegion { get; set; }               
+            internal DialInRegion[] dialInRegion { get; set; }               
         }        
     }
 }


### PR DESCRIPTION
the SDK was throwing the following Error because the dialininformation are in fact an array and not a single value.
See the sample 
```
var dialIn = await client.OnlineMeetings.GetPhoneDialInInformation();
```

```
{
  "externalDirectoryUri": "https://dialin.lync.com/c410d16f-2c01-4186-8503-e6e585592f51",
  "internalDirectoryUri": "https://dialin.lync.com/c410d16f-2c01-4186-8503-e6e585592f51",
  "defaultRegion": "Dial-in Number",
  "_links": {
    "self": {
      "href": "/ucwa/oauth/v1/applications/10367543470/onlineMeetings/phoneDialInInformation"
    }
  },
  "_embedded": {
    "dialInRegion": [
      {
        "languages": [
          "en-US",
          "fr-CA"
        ],
        "number": "+1********",
        "name": "Dial-in Number",
        "_links": {
          "self": {
            "href": "/ucwa/oauth/v1/applications/10367543470/onlineMeetings/phoneDialInInformation/dialInRegion/cEhcdN7tsMBS1TBl9UIBLEsdX_Ehkb7HLo0wf6aZW_w="
          }
        },
        "rel": "dialInRegion"
      }
    ]
  },
  "rel": "phoneDialInInformation"
}
```


```
{"Cannot deserialize the current JSON array (e.g. [1,2,3]) into type 'Microsoft.Skype.UCWA.Models.DialInRegion' because the type requires a JSON object (e.g. {\"name\":\"value\"}) to deserialize correctly.\r\nTo fix this error either change the JSON to a JSON object (e.g. {\"name\":\"value\"}) or change the deserialized type to an array or a type that implements a collection interface (e.g. ICollection, IList) like List<T> that can be deserialized from a JSON array. JsonArrayAttribute can also be added to the type to force it to deserialize from a JSON array.\r\nPath '_embedded.dialInRegion', line 11, position 21."}
```