### PR TITLE
Rethrow HttpRequestException only if Http fallback fails

### DIFF
--- a/UCWASDK/UCWASDK/UCWAClient.cs
+++ b/UCWASDK/UCWASDK/UCWAClient.cs
@@ -978,7 +978,10 @@ namespace Microsoft.Skype.UCWA
                         }
                         ex = ex.InnerException;
                     }
-                    throw;
+                    if (response == null)
+                    {
+                        throw;
+                    }
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Hi,

I started getting exceptions after updating to 1.0.2 and noticed that it was an AuthenticationException but the http fallback wasn't working due the throw being executed even if the HTTP Get worked. This change handles if the response is still null after the exception loop is broken.

Thanks,
Lazaro