### PR TITLE
Fixed: error handling swallows generic http errors

### DIFF
--- a/UCWASDK/UCWASDK/Services/HttpService.cs
+++ b/UCWASDK/UCWASDK/Services/HttpService.cs
@@ -270,6 +270,8 @@ namespace Microsoft.Skype.UCWA.Services
                         throw new ApplicationNotFoundException(error);
                     else
                         throw new ResourceNotFoundException(error);
+                default:
+                    throw new InvalidOperationException(error);
                     
             }
         }


### PR DESCRIPTION
Previous error was swallowing generic http errors (for example when setting bad parameters) and doing error masking.
Error like BadRequest are now being throwns as well with the response boddy as error message eg `{"code":"BadRequest","subcode":"ParameterValidationFailure","message":"Please check what you entered and try again.","debugInfo":{"diagnosticsCode":"2"}}`