### PR TITLE
Update UCWAClient.GetUserDiscoverUri

### DIFF
--- a/UCWASDK/UCWASDK/UCWAClient.cs
+++ b/UCWASDK/UCWASDK/UCWAClient.cs
@@ -964,7 +964,15 @@ namespace Microsoft.Skype.UCWA
                 HttpResponseMessage response = null;
                 try
                 {
-                    response = await client.GetAsync($"https://lyncdiscover.{Settings.Tenant}");
+                    try
+                    {
+                        response = await client.GetAsync($"https://lyncdiscoverinternal.{Settings.Tenant}");
+                    }
+                    catch
+                    {
+                        // request externally if internal discovery fails
+                        response = await client.GetAsync($"https://lyncdiscover.{Settings.Tenant}");
+                    }
                 }
                 catch (HttpRequestException hex)
                 {


### PR DESCRIPTION
Autodiscovery should start from "lyncdiscoverinternal" and if it fails use external reference "lyncdiscover". According to my experience, S4B on-premise setup may have only "lyncdiscoverinternal" and no external discovery link.
Source: https://msdn.microsoft.com/en-us/skype/ucwa/rooturl - recommends internal discovery first