### PR TITLE
cancellation token support and http time out retry policy

### DIFF
--- a/UCWASDK/TestClient/TokenService.cs
+++ b/UCWASDK/TestClient/TokenService.cs
@@ -50,7 +50,7 @@ namespace TestClient
                 // Get OAuth service url
                 var response = client.GetAsync(resourceId).Result;
                 var wwwAuthenticate = response.Headers.WwwAuthenticate;
-                var uri = wwwAuthenticate.Where(x => x.Scheme == "MsRtcOAuth").First().Parameter.Split(',').Where(y => y.Contains("href")).First().Split('=')[1].Replace("\"", "");
+                var uri = wwwAuthenticate.First(x => x.Scheme == "MsRtcOAuth").Parameter.Split(',').First(y => y.Contains("href")).Split('=')[1].Replace("\"", "");
 
                 // Obtain AccessToken
                 response = client.PostAsync(uri, new FormUrlEncodedContent(new List<KeyValuePair<string, string>>() { new KeyValuePair<string, string>("grant_type", "password"), new KeyValuePair<string, string>("username", username), new KeyValuePair<string, string>("password", password) })).Result;

--- a/UCWASDK/TestClient/UCWASample.cs
+++ b/UCWASDK/TestClient/UCWASample.cs
@@ -173,13 +173,13 @@ namespace TestClient
             ConsoleWrite_White("note: {0}", note.Message);
             foreach (var phone in client.Me.GetPhones().Result) { ConsoleWrite_White("phone: {0}", phone); }
             ConsoleWrite_White("photo: {0}", client.Me.GetPhoto().Result);
-            var presence = client.Me.GetPresencs().Result;
+            var presence = client.Me.GetPresence().Result;
             ConsoleWrite_White("presence: {0}", presence.Availability);
         }
 
         private void Presence()
         {
-            var presence = client.Me.GetPresencs().Result;
+            var presence = client.Me.GetPresence().Result;
             ConsoleWrite_White("Select new status");
             ConsoleWrite_White("Online | Offline | Away | BeRightBack | Busy | DoNotDisturb");
             var result = Console.ReadLine();

--- a/UCWASDK/UCWASDK/Models/Application.cs
+++ b/UCWASDK/UCWASDK/Models/Application.cs
@@ -76,9 +76,13 @@ namespace Microsoft.Skype.UCWA.Models
             internal OnlineMeetings onlineMeetings { get; set; }            
         }
 
-        public async Task<Policies> GetPolicies()
+        public Task<Policies> GetPolicies()
         {
-            return await HttpService.Get<Policies>(Links.policies);
+            return GetPolicies(HttpService.GetNewCancellationToken());
+        }
+        public async Task<Policies> GetPolicies(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<Policies>(Links.policies, cancellationToken);
         }
 
         public async Task<Application>Get()
@@ -89,9 +93,13 @@ namespace Microsoft.Skype.UCWA.Models
         {
             return await HttpService.Get<Application>(Self, cancellationToken);
         }
-        public async Task Delete()
+        public Task Delete()
         {
-            await HttpService.Delete(Self);
+            return Delete(HttpService.GetNewCancellationToken());
+        }
+        public async Task Delete(CancellationToken cancellationToken)
+        {
+            await HttpService.Delete(Self, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/Application.cs
+++ b/UCWASDK/UCWASDK/Models/Application.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -82,9 +83,12 @@ namespace Microsoft.Skype.UCWA.Models
 
         public async Task<Application>Get()
         {
-            return await HttpService.Get<Application>(Self);
+            return await HttpService.Get<Application>(Self, HttpService.GetNewCancellationToken());
         }
-
+        public async Task<Application> Get(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<Application>(Self, cancellationToken);
+        }
         public async Task Delete()
         {
             await HttpService.Delete(Self);

--- a/UCWASDK/UCWASDK/Models/ApplicationSharing.cs
+++ b/UCWASDK/UCWASDK/Models/ApplicationSharing.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -30,15 +31,21 @@ namespace Microsoft.Skype.UCWA.Models
             [JsonProperty("conversation")]
             internal UCWAHref conversation { get; set; }
         }
-
-        public async Task<ApplicationSharer> GetApplicationSharer()
+        public Task<ApplicationSharer> GetApplicationSharer()
         {
-            return await HttpService.Get<ApplicationSharer>(Links.applicationSharer);
+            return GetApplicationSharer(HttpService.GetNewCancellationToken());
         }
-
-        public async Task<Conversation> GetConversation()
+        public async Task<ApplicationSharer> GetApplicationSharer(CancellationToken cancellationToken)
         {
-            return await HttpService.Get<Conversation>(Links.conversation);
+            return await HttpService.Get<ApplicationSharer>(Links.applicationSharer, cancellationToken);
+        }
+        public Task<Conversation> GetConversation()
+        {
+            return GetConversation(HttpService.GetNewCancellationToken());
+        }
+        public async Task<Conversation> GetConversation(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<Conversation>(Links.conversation, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/Applications2.cs
+++ b/UCWASDK/UCWASDK/Models/Applications2.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Skype.UCWA.Services;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -7,10 +8,14 @@ namespace Microsoft.Skype.UCWA.Models
     /// Represents the entry point for registering this application with the server. 
     /// </summary>
     public class Applications2 : Applications
-    {          
-        public async Task<Application> Get()
+    {
+        public Task<Application> Get()
         {
-            return await HttpService.Get<Application>(Self);
+            return Get(HttpService.GetNewCancellationToken());
+        }
+        public async Task<Application> Get(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<Application>(Self, cancellationToken);
         }    
     }
 }

--- a/UCWASDK/UCWASDK/Models/Attendees.cs
+++ b/UCWASDK/UCWASDK/Models/Attendees.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -25,10 +26,13 @@ namespace Microsoft.Skype.UCWA.Models
             [JsonProperty("participant")]
             internal UCWAHref[] participant { get; set; }
         }
-
-        public async Task<List<Participant>> GetParticipants()
+        public Task<List<Participant>> GetParticipants()
         {
-            return await HttpService.GetList<Participant>(Links.participant);
+            return GetParticipants(HttpService.GetNewCancellationToken());
+        }
+        public async Task<List<Participant>> GetParticipants(CancellationToken cancellationToken)
+        {
+            return await HttpService.GetList<Participant>(Links.participant, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/AudioVideo.cs
+++ b/UCWASDK/UCWASDK/Models/AudioVideo.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Skype.UCWA.Enums;
 using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -32,20 +33,28 @@ namespace Microsoft.Skype.UCWA.Models
             internal UCWAHref self { get; set; }
 
             [JsonProperty("conversation")]
-            internal UCWAHref conversation { get; set; }       
-   
+            internal UCWAHref conversation { get; set; }
+
             [JsonProperty("videoLockedOnParticipant")]
             internal UCWAHref videoLockedOnParticipant { get; set; }
         }
-
-        public async Task<Conversation> GetConversation()
+        public Task<Conversation> GetConversation()
         {
-            return await HttpService.Get<Conversation>(Links.conversation);
+            return GetConversation(HttpService.GetNewCancellationToken());
         }
 
-        public async Task<VideoLockedOnParticipant> GetVideoLockedOnParticipant()
+        public async Task<Conversation> GetConversation(CancellationToken cancellationToken)
         {
-            return await HttpService.Get<VideoLockedOnParticipant>(Links.videoLockedOnParticipant);
+            return await HttpService.Get<Conversation>(Links.conversation, cancellationToken);
+        }
+
+        public Task<VideoLockedOnParticipant> GetVideoLockedOnParticipant()
+        {
+            return GetVideoLockedOnParticipant(HttpService.GetNewCancellationToken());
+        }
+        public async Task<VideoLockedOnParticipant> GetVideoLockedOnParticipant(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<VideoLockedOnParticipant>(Links.videoLockedOnParticipant, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/CallForwardingSettings.cs
+++ b/UCWASDK/UCWASDK/Models/CallForwardingSettings.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Skype.UCWA.Enums;
 using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -59,17 +60,24 @@ namespace Microsoft.Skype.UCWA.Models
             internal UnansweredCallSettings unansweredCallSettings { get; set; }
         }
         
-        public async Task TurnOffCallForwarding()
+        public Task TurnOffCallForwarding()
         {
-            await HttpService.Post(Links.turnOffCallForwarding, "");
+            return TurnOffCallForwarding(HttpService.GetNewCancellationToken());
         }
-
-        public async Task Update(ActivePeriod activePeriod, CallForwardingState activeSetting, UnansweredCallHandling unansweredCallHandling)
+        public async Task TurnOffCallForwarding(CancellationToken cancellationToken)
         {
-            this.ActivePeriod = activePeriod;
-            this.UnansweredCallHandling = unansweredCallHandling;
-            this.ActiveSetting = activeSetting;
-            await HttpService.Put(Self, this);
+            await HttpService.Post(Links.turnOffCallForwarding, "", cancellationToken);
+        }
+        public Task Update(ActivePeriod activePeriod, CallForwardingState activeSetting, UnansweredCallHandling unansweredCallHandling)
+        {
+            return Update(activePeriod, activeSetting, unansweredCallHandling, HttpService.GetNewCancellationToken());
+        }
+        public async Task Update(ActivePeriod activePeriod, CallForwardingState activeSetting, UnansweredCallHandling unansweredCallHandling, CancellationToken cancellationToken)
+        {
+            ActivePeriod = activePeriod;
+            UnansweredCallHandling = unansweredCallHandling;
+            ActiveSetting = activeSetting;
+            await HttpService.Put(Self, this, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/Communication.cs
+++ b/UCWASDK/UCWASDK/Models/Communication.cs
@@ -3,6 +3,7 @@ using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -58,17 +59,29 @@ namespace Microsoft.Skype.UCWA.Models
             internal StartPhoneAudio2 startPhoneAudio { get; set; }
         }
 
-        public async Task<ConversationLogs> GetConversationLogs()
+        public Task<ConversationLogs> GetConversationLogs()
         {
-            return await HttpService.Get<ConversationLogs>(Links.conversationLogs);
+            return GetConversationLogs(HttpService.GetNewCancellationToken());
+        }
+        public async Task<ConversationLogs> GetConversationLogs(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<ConversationLogs>(Links.conversationLogs, cancellationToken);
         }
 
-        public async Task<Conversations> GetConversations()
+        public Task<Conversations> GetConversations()
         {
-            return await HttpService.Get<Conversations>(Links.conversations);
+            return GetConversations(HttpService.GetNewCancellationToken());
+        }
+        public async Task<Conversations> GetConversations(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<Conversations>(Links.conversations, cancellationToken);
         }
         
-        public async Task JoinOnlineMeeting(string onlineMeetingUri, string subject, Importance importance)
+        public Task JoinOnlineMeeting(string onlineMeetingUri, string subject, Importance importance)
+        {
+            return JoinOnlineMeeting(onlineMeetingUri, subject, importance, HttpService.GetNewCancellationToken());
+        }
+        public async Task JoinOnlineMeeting(string onlineMeetingUri, string subject, Importance importance, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(onlineMeetingUri) || string.IsNullOrEmpty(subject))
                 return;
@@ -80,15 +93,23 @@ namespace Microsoft.Skype.UCWA.Models
             body["operationid"] = Guid.NewGuid();
             body["threadid"] = Guid.NewGuid();
 
-            await HttpService.Post(Links.joinOnlineMeeting, body);
+            await HttpService.Post(Links.joinOnlineMeeting, body, cancellationToken);
         }
 
-        public async Task<MissedItems> GetMissedItems()
+        public Task<MissedItems> GetMissedItems()
         {
-            return await HttpService.Get<MissedItems>(Links.missedItems);
+            return GetMissedItems(HttpService.GetNewCancellationToken());
+        }
+        public async Task<MissedItems> GetMissedItems(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<MissedItems>(Links.missedItems, cancellationToken);
         }
 
-        public async Task<string> StartMessaging(string sipName, string subject, Importance importance, string message)
+        public Task<string> StartMessaging(string sipName, string subject, Importance importance, string message)
+        {
+            return StartMessaging(sipName, subject, importance, message, HttpService.GetNewCancellationToken());
+        }
+        public async Task<string> StartMessaging(string sipName, string subject, Importance importance, string message, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(sipName))
                 return "";
@@ -113,15 +134,19 @@ namespace Microsoft.Skype.UCWA.Models
                 }
             };
 
-            return await HttpService.Post(Links.startMessaging, invitation);
+            return await HttpService.Post(Links.startMessaging, invitation, cancellationToken);
         }
 
-        public async Task<string> StartOnlineMeeting(string subject, Importance importance)
+        public Task<string> StartOnlineMeeting(string subject, Importance importance)
+        {
+            return StartOnlineMeeting(subject, importance, HttpService.GetNewCancellationToken());
+        }
+        public async Task<string> StartOnlineMeeting(string subject, Importance importance, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(subject))
                 return "";
 
-            OnlineMeetingInvitation invitation = new Models.OnlineMeetingInvitation()
+            OnlineMeetingInvitation invitation = new OnlineMeetingInvitation()
             {
                 Subject = subject,
                 Importance = importance,
@@ -129,15 +154,19 @@ namespace Microsoft.Skype.UCWA.Models
                 ThreadId = Guid.NewGuid().ToString()
             };
 
-            return await HttpService.Post(Links.startOnlineMeeting, invitation);
+            return await HttpService.Post(Links.startOnlineMeeting, invitation, cancellationToken);
         }
 
-        public async Task StartPhoneAudio(string phoneNumber, string to, string subject, Importance importance)
+        public Task StartPhoneAudio(string phoneNumber, string to, string subject, Importance importance)
+        {
+            return StartPhoneAudio(phoneNumber, to, subject, importance, HttpService.GetNewCancellationToken());
+        }
+        public async Task StartPhoneAudio(string phoneNumber, string to, string subject, Importance importance, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(phoneNumber) || string.IsNullOrEmpty(to) || string.IsNullOrEmpty(subject))
                 return;
             
-            PhoneAudioInvitation invitation = new Models.PhoneAudioInvitation()
+            PhoneAudioInvitation invitation = new PhoneAudioInvitation()
             {
                 PhoneNumber = phoneNumber,
                 To = to,
@@ -147,12 +176,16 @@ namespace Microsoft.Skype.UCWA.Models
                 ThreadId = Guid.NewGuid().ToString()
             };
  
-            await HttpService.Post(Links.startPhoneAudio, invitation);
+            await HttpService.Post(Links.startPhoneAudio, invitation, cancellationToken);
         }
 
-        public async Task Update()
+        public Task Update()
         {
-            await HttpService.Put(Self, this);
+            return Update(HttpService.GetNewCancellationToken());
+        }
+        public async Task Update(CancellationToken cancellationToken)
+        {
+            await HttpService.Put(Self, this, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/Contact.cs
+++ b/UCWASDK/UCWASDK/Models/Contact.cs
@@ -2,6 +2,7 @@
 using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -84,34 +85,58 @@ namespace Microsoft.Skype.UCWA.Models
             internal UCWAHref contactSupportedModalities { get; set; }
         }
 
-        public async Task<ContactLocation> GetContactLocation()
+        public Task<ContactLocation> GetContactLocation()
         {
-            return await HttpService.Get<ContactLocation>(Links.contactLocation);
+            return GetContactLocation(HttpService.GetNewCancellationToken());
+        }
+        public async Task<ContactLocation> GetContactLocation(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<ContactLocation>(Links.contactLocation, cancellationToken);
         }
 
-        public async Task<ContactNote> GetContactNote()
+        public Task<ContactNote> GetContactNote()
         {
-            return await HttpService.Get<ContactNote>(Links.contactNote);
+            return GetContactNote(HttpService.GetNewCancellationToken());
+        }
+        public async Task<ContactNote> GetContactNote(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<ContactNote>(Links.contactNote, cancellationToken);
         }
 
-        public async Task<byte[]> GetContactPhoto()
+        public Task<byte[]> GetContactPhoto()
         {
-            return await HttpService.GetBinary(Links.contactPhoto);
+            return GetContactPhoto(HttpService.GetNewCancellationToken());
+        }
+        public async Task<byte[]> GetContactPhoto(CancellationToken cancellationToken)
+        {
+            return await HttpService.GetBinary(Links.contactPhoto, cancellationToken);
         }
 
-        public async Task<ContactPresence> GetContactPresence()
+        public Task<ContactPresence> GetContactPresence()
         {
-            return await HttpService.Get<ContactPresence>(Links.contactPresence);
+            return GetContactPresence(HttpService.GetNewCancellationToken());
+        }
+        public async Task<ContactPresence> GetContactPresence(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<ContactPresence>(Links.contactPresence, cancellationToken);
         }
 
-        public async Task<ContactPrivacyRelationship> GetContactPrivacyRelationship()
+        public Task<ContactPrivacyRelationship> GetContactPrivacyRelationship()
         {
-            return await HttpService.Get<ContactPrivacyRelationship>(Links.contactPrivacyRelationship);
+            return GetContactPrivacyRelationship(HttpService.GetNewCancellationToken());
+        }
+        public async Task<ContactPrivacyRelationship> GetContactPrivacyRelationship(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<ContactPrivacyRelationship>(Links.contactPrivacyRelationship, cancellationToken);
         }
 
-        public async Task<ContactSupportedModalities> GetContactSupportedModalities()
+        public Task<ContactSupportedModalities> GetContactSupportedModalities()
         {
-            return await HttpService.Get<ContactSupportedModalities>(Links.contactSupportedModalities);
+            return GetContactSupportedModalities(HttpService.GetNewCancellationToken());
+        }
+        public async Task<ContactSupportedModalities> GetContactSupportedModalities(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<ContactSupportedModalities>(Links.contactSupportedModalities, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/ContactPrivacyRelationship2.cs
+++ b/UCWASDK/UCWASDK/Models/ContactPrivacyRelationship2.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Skype.UCWA.Enums;
 using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -29,14 +30,22 @@ namespace Microsoft.Skype.UCWA.Models
             internal UCWAHref resetContactPrivacyRelationship { get; set; }
         }
 
-        public async Task ResetContactPrivacyRelationship()
+        public Task ResetContactPrivacyRelationship()
         {
-            await HttpService.Post(Links.resetContactPrivacyRelationship, "", "2");
+            return ResetContactPrivacyRelationship(HttpService.GetNewCancellationToken());
+        }
+        public async Task ResetContactPrivacyRelationship(CancellationToken cancellationToken)
+        {
+            await HttpService.Post(Links.resetContactPrivacyRelationship, "", cancellationToken, "2");
         }
 
-        public async Task Update()
+        public Task Update()
         {
-            await HttpService.Put(Self, this, "2");
+            return Update(HttpService.GetNewCancellationToken());
+        }
+        public async Task Update(CancellationToken cancellationToken)
+        {
+            await HttpService.Put(Self, this, cancellationToken, "2");
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/Conversation.cs
+++ b/UCWASDK/UCWASDK/Models/Conversation.cs
@@ -3,6 +3,7 @@ using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -103,7 +104,11 @@ namespace Microsoft.Skype.UCWA.Models
             internal UCWAHref phoneAudio { get; set; }
         }
 
-        public async Task AddParticipant(string to)
+        public Task AddParticipant(string to)
+        {
+            return AddParticipant(to, HttpService.GetNewCancellationToken());
+        }
+        public async Task AddParticipant(string to, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(to))
                 return;
@@ -112,83 +117,143 @@ namespace Microsoft.Skype.UCWA.Models
             body["to"] = to;
             body["operationid"] = Guid.NewGuid();
 
-            await HttpService.Post(Links.addParticipant, body);
+            await HttpService.Post(Links.addParticipant, body, cancellationToken);
         }
 
-        public async Task<ApplicationSharing> GetApplicationSharing()
+        public Task<ApplicationSharing> GetApplicationSharing()
         {
-            return await HttpService.Get<ApplicationSharing>(Links.applicationSharing);
+            return GetApplicationSharing(HttpService.GetNewCancellationToken());
         }
-
-        public async Task<Attendees> GetAttendees()
+        public async Task<ApplicationSharing> GetApplicationSharing(CancellationToken cancellationToken)
         {
-            return await HttpService.Get<Attendees>(Links.attendees);
+            return await HttpService.Get<ApplicationSharing>(Links.applicationSharing, cancellationToken);
         }
 
-        public async Task<AudioVideo> GetAudioVideo()
+        public Task<Attendees> GetAttendees()
         {
-            return await HttpService.Get<AudioVideo>(Links.audioVideo);
+            return GetAttendees(HttpService.GetNewCancellationToken());
         }
-
-        public async Task<DataCollaboration> GetDataCollaboration()
+        public async Task<Attendees> GetAttendees(CancellationToken cancellationToken)
         {
-            return await HttpService.Get<DataCollaboration>(Links.dataCollaboration);
+            return await HttpService.Get<Attendees>(Links.attendees, cancellationToken);
         }
 
-        public async Task DisableAudienceMessaging()
+        public Task<AudioVideo> GetAudioVideo()
         {
-            await HttpService.Post(Links.disableAudienceMessaging, "");
+            return GetAudioVideo(HttpService.GetNewCancellationToken());
         }
-
-        public async Task DisableAudienceMuteLock()
+        public async Task<AudioVideo> GetAudioVideo(CancellationToken cancellationToken)
         {
-            await HttpService.Post(Links.disableAudienceMuteLock, "");
+            return await HttpService.Get<AudioVideo>(Links.audioVideo, cancellationToken);
         }
 
-        public async Task EnableAudienceMessaging()
+        public Task<DataCollaboration> GetDataCollaboration()
         {
-            await HttpService.Post(Links.enableAudienceMessaging, "");
+            return GetDataCollaboration(HttpService.GetNewCancellationToken());
         }
-
-        public async Task EnableAudienceMuteLock()
+        public async Task<DataCollaboration> GetDataCollaboration(CancellationToken cancellationToken)
         {
-            await HttpService.Post(Links.enableAudienceMuteLock, "");
+            return await HttpService.Get<DataCollaboration>(Links.dataCollaboration, cancellationToken);
         }
 
-        public async Task Delete()
+        public Task DisableAudienceMessaging()
+        {
+            return DisableAudienceMessaging(HttpService.GetNewCancellationToken());
+        }
+        public async Task DisableAudienceMessaging(CancellationToken cancellationToken)
+        {
+            await HttpService.Post(Links.disableAudienceMessaging, "", cancellationToken);
+        }
+
+        public Task DisableAudienceMuteLock()
+        {
+            return DisableAudienceMuteLock(HttpService.GetNewCancellationToken());
+        }
+        public async Task DisableAudienceMuteLock(CancellationToken cancellationToken)
+        {
+            await HttpService.Post(Links.disableAudienceMuteLock, "", cancellationToken);
+        }
+
+        public Task EnableAudienceMessaging()
+        {
+            return EnableAudienceMessaging(HttpService.GetNewCancellationToken());
+        }
+        public async Task EnableAudienceMessaging(CancellationToken cancellationToken)
+        {
+            await HttpService.Post(Links.enableAudienceMessaging, "", cancellationToken);
+        }
+
+        public Task EnableAudienceMuteLock()
+        {
+            return EnableAudienceMuteLock(HttpService.GetNewCancellationToken());
+        }
+        public async Task EnableAudienceMuteLock(CancellationToken cancellationToken)
+        {
+            await HttpService.Post(Links.enableAudienceMuteLock, "", cancellationToken);
+        }
+
+        public Task Delete()
+        {
+            return Delete(HttpService.GetNewCancellationToken());
+        }
+        public async Task Delete(CancellationToken cancellationToken)
         {
             var uri = Self;
-            await HttpService.Delete(uri);
+            await HttpService.Delete(uri, cancellationToken);
         }
 
-        public async Task<Leaders> GetLeaders()
+        public Task<Leaders> GetLeaders()
         {
-            return await HttpService.Get<Leaders>(Links.leaders);
+            return GetLeaders(HttpService.GetNewCancellationToken());
+        }
+        public async Task<Leaders> GetLeaders(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<Leaders>(Links.leaders, cancellationToken);
         }
 
-        public async Task<Lobby> GetLobby()
+        public Task<Lobby> GetLobby()
         {
-            return await HttpService.Get<Lobby>(Links.lobby);
+            return GetLobby(HttpService.GetNewCancellationToken());
+        }
+        public async Task<Lobby> GetLobby(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<Lobby>(Links.lobby, cancellationToken);
         }
 
-        public async Task<LocalParticipant> GetLocalParticipant()
+        public Task<LocalParticipant> GetLocalParticipant()
         {
-            return await HttpService.Get<LocalParticipant>(Links.localParticipant);
+            return GetLocalParticipant(HttpService.GetNewCancellationToken());
+        }
+        public async Task<LocalParticipant> GetLocalParticipant(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<LocalParticipant>(Links.localParticipant, cancellationToken);
         }
 
-        public async Task<Messaging> GetMessaging()
+        public Task<Messaging> GetMessaging()
         {
-            return await HttpService.Get<Messaging>(Links.messaging);
+            return GetMessaging(HttpService.GetNewCancellationToken());
+        }
+        public async Task<Messaging> GetMessaging(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<Messaging>(Links.messaging, cancellationToken);
         }
 
-        public async Task<OnlineMeeting> GetOnlineMeeting()
+        public Task<OnlineMeeting> GetOnlineMeeting()
         {
-            return await HttpService.Get<OnlineMeeting>(Links.onlineMeeting);
+            return GetOnlineMeeting(HttpService.GetNewCancellationToken());
+        }
+        public async Task<OnlineMeeting> GetOnlineMeeting(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<OnlineMeeting>(Links.onlineMeeting, cancellationToken);
         }
 
-        public async Task<PhoneAudio> GetPhoneAudio()
+        public Task<PhoneAudio> GetPhoneAudio()
         {
-            return await HttpService.Get<PhoneAudio>(Links.phoneAudio);
+            return GetPhoneAudio(HttpService.GetNewCancellationToken());
+        }
+        public async Task<PhoneAudio> GetPhoneAudio(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<PhoneAudio>(Links.phoneAudio, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/ConversationLog.cs
+++ b/UCWASDK/UCWASDK/Models/ConversationLog.cs
@@ -2,6 +2,7 @@
 using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -80,7 +81,11 @@ namespace Microsoft.Skype.UCWA.Models
             internal ConversationLogRecipient[] conversationLogRecipients { get; set; }
         }
         
-        public async Task ContinueMessaging(MessageFormat messageFormat, string message)
+        public Task ContinueMessaging(MessageFormat messageFormat, string message)
+        {
+            return ContinueMessaging(messageFormat, message, HttpService.GetNewCancellationToken());
+        }
+        public async Task ContinueMessaging(MessageFormat messageFormat, string message, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(message))
                 return;
@@ -104,10 +109,14 @@ namespace Microsoft.Skype.UCWA.Models
                 }
             };
 
-            await HttpService.Post(Links.continueMessaging, messagingInvitation);
+            await HttpService.Post(Links.continueMessaging, messagingInvitation, cancellationToken);
         }
 
-        public async Task ContinuePhoneAudio(string phoneNumber)
+        public Task ContinuePhoneAudio(string phoneNumber)
+        {
+            return ContinuePhoneAudio(phoneNumber, HttpService.GetNewCancellationToken());
+        }
+        public async Task ContinuePhoneAudio(string phoneNumber, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(phoneNumber))
                 return;
@@ -118,22 +127,34 @@ namespace Microsoft.Skype.UCWA.Models
                 PhoneNumber = phoneNumber
             };
             
-            await HttpService.Post(Links.continuePhoneAudio, phoneAudioInvitation);
+            await HttpService.Post(Links.continuePhoneAudio, phoneAudioInvitation, cancellationToken);
         }
 
-        public async Task<ConversationLogTranscripts> GetConversationLogTranscripts()
+        public Task<ConversationLogTranscripts> GetConversationLogTranscripts()
         {
-            return await HttpService.Get<ConversationLogTranscripts>(Links.conversationLogTranscripts);
+            return GetConversationLogTranscripts(HttpService.GetNewCancellationToken());
+        }
+        public async Task<ConversationLogTranscripts> GetConversationLogTranscripts(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<ConversationLogTranscripts>(Links.conversationLogTranscripts, cancellationToken);
         }
 
-        public async Task MarkAsRead()
+        public Task MarkAsRead()
         {
-            await HttpService.Post(Links.markAsRead, "");
+            return MarkAsRead(HttpService.GetNewCancellationToken());
+        }
+        public async Task MarkAsRead(CancellationToken cancellationToken)
+        {
+            await HttpService.Post(Links.markAsRead, "", cancellationToken);
         }
 
-        public async Task Delete()
+        public Task Delete()
         {
-            await HttpService.Delete(Self);
+            return Delete(HttpService.GetNewCancellationToken());
+        }
+        public async Task Delete(CancellationToken cancellationToken)
+        {
+            await HttpService.Delete(Self, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/ConversationLogRecipient.cs
+++ b/UCWASDK/UCWASDK/Models/ConversationLogRecipient.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -37,19 +38,31 @@ namespace Microsoft.Skype.UCWA.Models
             internal UCWAHref contactPresence { get; set; }
         }
 
-        public async Task<Contact> GetContact()
+        public Task<Contact> GetContact()
         {
-            return await HttpService.Get<Contact>(Links.contact);
+            return GetContact(HttpService.GetNewCancellationToken());
+        }
+        public async Task<Contact> GetContact(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<Contact>(Links.contact, cancellationToken);
         }
 
-        public async Task<byte[]> GetContactPhone()
+        public Task<byte[]> GetContactPhone()
         {
-            return await HttpService.GetBinary(Links.contactPhoto);
+            return GetContactPhone(HttpService.GetNewCancellationToken());
+        }
+        public async Task<byte[]> GetContactPhone(CancellationToken cancellationToken)
+        {
+            return await HttpService.GetBinary(Links.contactPhoto, cancellationToken);
         }
 
-        public async Task<ContactPresence> GetContactPresence()
+        public Task<ContactPresence> GetContactPresence()
         {
-            return await HttpService.Get<ContactPresence>(Links.contactPresence);
+            return GetContactPresence(HttpService.GetNewCancellationToken());
+        }
+        public async Task<ContactPresence> GetContactPresence(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<ContactPresence>(Links.contactPresence, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/ConversationLogTranscript.cs
+++ b/UCWASDK/UCWASDK/Models/ConversationLogTranscript.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -55,14 +56,22 @@ namespace Microsoft.Skype.UCWA.Models
             internal MessageTranscript messageTranscript { get; set; }
         }
 
-        public async Task<Contact> GetContact()
+        public Task<Contact> GetContact()
         {
-            return await HttpService.Get<Contact>(Links.contact);
+            return GetContact(HttpService.GetNewCancellationToken());
+        }
+        public async Task<Contact> GetContact(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<Contact>(Links.contact, cancellationToken);
         }
 
-        public async Task<Me> GetMe()
+        public Task<Me> GetMe()
         {
-            return await HttpService.Get<Me>(Links.me);
+            return GetMe(HttpService.GetNewCancellationToken());
+        }
+        public async Task<Me> GetMe(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<Me>(Links.me, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/ConversationLogTranscripts.cs
+++ b/UCWASDK/UCWASDK/Models/ConversationLogTranscripts.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -32,7 +33,7 @@ namespace Microsoft.Skype.UCWA.Models
 
             [JsonProperty("nextConversationLogTranscripts")]
             internal UCWAHref nextConversationLogTranscripts { get; set; }
-            public NextConversationLogTranscripts NextConversationLogTranscripts { get { return HttpService.Get<NextConversationLogTranscripts>(nextConversationLogTranscripts).Result; } }
+            public NextConversationLogTranscripts NextConversationLogTranscripts { get { return HttpService.Get<NextConversationLogTranscripts>(nextConversationLogTranscripts, HttpService.GetNewCancellationToken()).Result; } }
         }
 
         internal class InternalEmbedded
@@ -41,9 +42,13 @@ namespace Microsoft.Skype.UCWA.Models
             internal ConversationLogTranscript conversationLogTranscript { get; set; }
         }
 
-        public async Task<NextConversationLogTranscripts> GetNextConversationLogTranscripts()
+        public Task<NextConversationLogTranscripts> GetNextConversationLogTranscripts()
         {
-            return await HttpService.Get<NextConversationLogTranscripts>(Links.nextConversationLogTranscripts);
+            return GetNextConversationLogTranscripts(HttpService.GetNewCancellationToken());
+        }
+        public async Task<NextConversationLogTranscripts> GetNextConversationLogTranscripts(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<NextConversationLogTranscripts>(Links.nextConversationLogTranscripts, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/ConversationLogs.cs
+++ b/UCWASDK/UCWASDK/Models/ConversationLogs.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -25,9 +26,13 @@ namespace Microsoft.Skype.UCWA.Models
             internal UCWAHref[] conversationLog { get; set; }
         }
 
-        public async Task<List<ConversationLog>> GetConversationLogs()
+        public Task<List<ConversationLog>> GetConversationLogs()
         {
-            return await HttpService.GetList<ConversationLog>(Links.conversationLog);
+            return GetConversationLogs(HttpService.GetNewCancellationToken());
+        }
+        public async Task<List<ConversationLog>> GetConversationLogs(CancellationToken cancellationToken)
+        {
+            return await HttpService.GetList<ConversationLog>(Links.conversationLog, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/Conversations.cs
+++ b/UCWASDK/UCWASDK/Models/Conversations.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -25,9 +26,13 @@ namespace Microsoft.Skype.UCWA.Models
             internal UCWAHref[] conversation { get; set; }
         }
 
-        public async Task<List<Conversation>> GetConversations()
+        public Task<List<Conversation>> GetConversations()
         {
-            return await HttpService.GetList<Conversation>(Links.conversation);
+            return GetConversations(HttpService.GetNewCancellationToken());
+        }
+        public async Task<List<Conversation>> GetConversations(CancellationToken cancellationToken)
+        {
+            return await HttpService.GetList<Conversation>(Links.conversation, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/DataCollaboration.cs
+++ b/UCWASDK/UCWASDK/Models/DataCollaboration.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -28,9 +29,13 @@ namespace Microsoft.Skype.UCWA.Models
             internal UCWAHref conversation { get; set; }
         }
 
-        public async Task<Conversation> GetConversation()
+        public Task<Conversation> GetConversation()
         {
-            return await HttpService.Get<Conversation>(Links.conversation);
+            return GetConversation(HttpService.GetNewCancellationToken());
+        }
+        public async Task<Conversation> GetConversation(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<Conversation>(Links.conversation, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/DistributionGroup.cs
+++ b/UCWASDK/UCWASDK/Models/DistributionGroup.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -64,30 +65,49 @@ namespace Microsoft.Skype.UCWA.Models
             internal DistributionGroup[] distributionGroups { get; set; }
         }
 
-        public async Task AddToContactList()
+        public Task AddToContactList()
         {
-            var uri = Links.addToContactList.Href + "?displayName=" + Name + "&smtpAddress=" + Uri;
-            await HttpService.Post(Links.addToContactList, "");
+            return AddToContactList(HttpService.GetNewCancellationToken());
+        }
+        public async Task AddToContactList(CancellationToken cancellationToken)
+        {
+            await HttpService.Post(Links.addToContactList, "", cancellationToken);
         }
         
-        public async Task<DistributionGroup> ExpandDistributionGroup()
+        public Task<DistributionGroup> ExpandDistributionGroup()
         {
-            return await HttpService.Get<DistributionGroup>(Links.expandDistributionGroup);
+            return ExpandDistributionGroup(HttpService.GetNewCancellationToken());
+        }
+        public async Task<DistributionGroup> ExpandDistributionGroup(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<DistributionGroup>(Links.expandDistributionGroup, cancellationToken);
         }
 
-        public async Task<GroupContacts> GetGroupContacts()
+        public Task<GroupContacts> GetGroupContacts()
         {
-            return await HttpService.Get<GroupContacts>(Links.groupContacts);
+            return GetGroupContacts(HttpService.GetNewCancellationToken());
+        }
+        public async Task<GroupContacts> GetGroupContacts(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<GroupContacts>(Links.groupContacts, cancellationToken);
         }
 
-        public async Task RemoveFromContactList()
+        public Task RemoveFromContactList()
         {
-            await HttpService.Post(Links.removeFromContactList, "");
+            return RemoveFromContactList(HttpService.GetNewCancellationToken());
+        }
+        public async Task RemoveFromContactList(CancellationToken cancellationToken)
+        {
+            await HttpService.Post(Links.removeFromContactList, "", cancellationToken);
         }
 
-        public async Task SubscribeToGroupPresence()
+        public Task SubscribeToGroupPresence()
         {
-            await HttpService.Post(Links.subscribeToGroupPresence, "");
+            return SubscribeToGroupPresence(HttpService.GetNewCancellationToken());
+        }
+        public async Task SubscribeToGroupPresence(CancellationToken cancellationToken)
+        {
+            await HttpService.Post(Links.subscribeToGroupPresence, "", cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/Group.cs
+++ b/UCWASDK/UCWASDK/Models/Group.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -40,28 +41,44 @@ namespace Microsoft.Skype.UCWA.Models
             internal SubscribeToGroupPresence subscribeToGroupPresence { get; set; }
         }
 
-        public async Task<DistributionGroup> ExpandDistributionGroup()
+        public Task<DistributionGroup> ExpandDistributionGroup()
         {
-            return await HttpService.Get<DistributionGroup>(Links.expandDistributionGroup);
+            return ExpandDistributionGroup(HttpService.GetNewCancellationToken());
+        }
+        public async Task<DistributionGroup> ExpandDistributionGroup(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<DistributionGroup>(Links.expandDistributionGroup, cancellationToken);
         }
 
-        public async Task<GroupContacts> GetGroupContacts()
+        public Task<GroupContacts> GetGroupContacts()
         {
-            return await HttpService.Get<GroupContacts>(Links.groupContacts);
+            return GetGroupContacts(HttpService.GetNewCancellationToken());
+        }
+        public async Task<GroupContacts> GetGroupContacts(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<GroupContacts>(Links.groupContacts, cancellationToken);
         }
 
-        public async Task<GroupMemberships> GetGroupMemberships()
+        public Task<GroupMemberships> GetGroupMemberships()
         {
-            return await HttpService.Get<GroupMemberships>(Links.groupMemberships);
+            return GetGroupMemberships(HttpService.GetNewCancellationToken());
+        }
+        public async Task<GroupMemberships> GetGroupMemberships(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<GroupMemberships>(Links.groupMemberships, cancellationToken);
         }
 
-        public async Task<PresenceSubscription> SubscribeToGroupPresence(int duration = 30)
+        public Task<PresenceSubscription> SubscribeToGroupPresence(int duration = 30)
+        {
+            return SubscribeToGroupPresence(HttpService.GetNewCancellationToken());
+        }
+        public async Task<PresenceSubscription> SubscribeToGroupPresence(CancellationToken cancellationToken, int duration = 30)
         {
             if (duration > 30 && duration < 10)
                 return null;
 
             var uri = Links.subscribeToGroupPresence.Href + "&duration=" + duration;
-            return await HttpService.Post<PresenceSubscription>(uri, null);
+            return await HttpService.Post<PresenceSubscription>(uri, null, cancellationToken);
         }
     }    
 }

--- a/UCWASDK/UCWASDK/Models/Group2.cs
+++ b/UCWASDK/UCWASDK/Models/Group2.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -15,14 +16,22 @@ namespace Microsoft.Skype.UCWA.Models
     /// </summary>
     public class Group2 : Group
     {
-        public async Task Update()
+        public Task Update()
         {
-            await HttpService.Put(Self, this, "2");
+            return Update(HttpService.GetNewCancellationToken());
+        }
+        public async Task Update(CancellationToken cancellationToken)
+        {
+            await HttpService.Put(Self, this, cancellationToken, "2");
         }
 
-        public async Task Delete()
+        public Task Delete()
         {
-            await HttpService.Delete(Self, "2");
+            return Delete(HttpService.GetNewCancellationToken());
+        }
+        public async Task Delete(CancellationToken cancellationToken)
+        {
+            await HttpService.Delete(Self, cancellationToken, "2");
         }
     }    
 }

--- a/UCWASDK/UCWASDK/Models/ImmediateForwardSettings.cs
+++ b/UCWASDK/UCWASDK/Models/ImmediateForwardSettings.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Skype.UCWA.Enums;
 using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -38,25 +39,41 @@ namespace Microsoft.Skype.UCWA.Models
             internal ImmediateForwardToVoicemail immediateForwardToVoicemail { get; set; }
         }
 
-        public async Task<Contact> GetContact()
+        public Task<Contact> GetContact()
         {
-            return await HttpService.Get<Contact>(Links.contact);
+            return GetContact(HttpService.GetNewCancellationToken());
+        }
+        public async Task<Contact> GetContact(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<Contact>(Links.contact, cancellationToken);
         }
 
-        public async Task ImmediateForwardToContact()
+        public Task ImmediateForwardToContact()
+        {
+            return ImmediateForwardToContact(HttpService.GetNewCancellationToken());
+        }
+        public async Task ImmediateForwardToContact(CancellationToken cancellationToken)
         {
             var uri = Links.immediateForwardToContact.Href + "?target=" + Target;
-            await HttpService.Post(uri, "");
+            await HttpService.Post(uri, "", cancellationToken);
         }
 
-        public async Task ImmediateForwardToDelegates()
+        public Task ImmediateForwardToDelegates()
         {
-            await HttpService.Post(Links.immediateForwardToDelegates, "");
+            return ImmediateForwardToDelegates(HttpService.GetNewCancellationToken());
+        }
+        public async Task ImmediateForwardToDelegates(CancellationToken cancellationToken)
+        {
+            await HttpService.Post(Links.immediateForwardToDelegates, "", cancellationToken);
         }
 
-        public async Task ImmediateForwardToVoicemail()
+        public Task ImmediateForwardToVoicemail()
         {
-            await HttpService.Post(Links.immediateForwardToVoicemail, "");
+            return ImmediateForwardToVoicemail(HttpService.GetNewCancellationToken());
+        }
+        public async Task ImmediateForwardToVoicemail(CancellationToken cancellationToken)
+        {
+            await HttpService.Post(Links.immediateForwardToVoicemail, "", cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/Leaders.cs
+++ b/UCWASDK/UCWASDK/Models/Leaders.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -25,9 +26,13 @@ namespace Microsoft.Skype.UCWA.Models
             internal UCWAHref[] participant { get; set; }
         }
 
-        public async Task<List<Participant>> GetParticipants()
+        public Task<List<Participant>> GetParticipants()
         {
-            return await HttpService.GetList<Participant>(Links.participant);
+            return GetParticipants(HttpService.GetNewCancellationToken());
+        }
+        public async Task<List<Participant>> GetParticipants(CancellationToken cancellationToken)
+        {
+            return await HttpService.GetList<Participant>(Links.participant, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/Lobby.cs
+++ b/UCWASDK/UCWASDK/Models/Lobby.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
@@ -26,9 +27,13 @@ namespace Microsoft.Skype.UCWA.Models
             internal UCWAHref[] participant { get; set; }
         }
 
-        public async Task<List<Participant>> GetParticipants()
+        public Task<List<Participant>> GetParticipants()
         {
-            return await HttpService.GetList<Participant>(Links.participant);
+            return GetParticipants(HttpService.GetNewCancellationToken());
+        }
+        public async Task<List<Participant>> GetParticipants(CancellationToken cancellationToken)
+        {
+            return await HttpService.GetList<Participant>(Links.participant, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/LocalParticipant.cs
+++ b/UCWASDK/UCWASDK/Models/LocalParticipant.cs
@@ -2,6 +2,7 @@
 using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -84,64 +85,112 @@ namespace Microsoft.Skype.UCWA.Models
             internal UCWAHref participantVideo { get; set; }
         }
 
-        public async Task<Contact> GetContact()
+        public Task<Contact> GetContact()
         {
-            return await HttpService.Get<Contact>(Links.contact);
+            return GetContact(HttpService.GetNewCancellationToken());
+        }
+        public async Task<Contact> GetContact(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<Contact>(Links.contact, cancellationToken);
         }
 
-        public async Task<byte[]> GetContactPhone()
+        public Task<byte[]> GetContactPhone()
         {
-            return await HttpService.GetBinary(Links.contactPhoto);
+            return GetContactPhone(HttpService.GetNewCancellationToken());
+        }
+        public async Task<byte[]> GetContactPhone(CancellationToken cancellationToken)
+        {
+            return await HttpService.GetBinary(Links.contactPhoto, cancellationToken);
         }
 
-        public async Task<ContactPresence> GetContactPresence()
+        public Task<ContactPresence> GetContactPresence()
         {
-            return await HttpService.Get<ContactPresence>(Links.contactPresence);
+            return GetContactPresence(HttpService.GetNewCancellationToken());
+        }
+        public async Task<ContactPresence> GetContactPresence(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<ContactPresence>(Links.contactPresence, cancellationToken);
         }
 
-        public async Task<Conversation> GetConversation()
+        public Task<Conversation> GetConversation()
         {
-            return await HttpService.Get<Conversation>(Links.conversation);
+            return GetConversation(HttpService.GetNewCancellationToken());
+        }
+        public async Task<Conversation> GetConversation(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<Conversation>(Links.conversation, cancellationToken);
         }
 
-        public async Task Eject()
+        public Task Eject()
         {
-            await HttpService.Post(Links.eject, "");
+            return Eject(HttpService.GetNewCancellationToken());
+        }
+        public async Task Eject(CancellationToken cancellationToken)
+        {
+            await HttpService.Post(Links.eject, "", cancellationToken);
         }
 
-        public async Task<Me> GetMe()
+        public Task<Me> GetMe()
         {
-            return await HttpService.Get<Me>(Links.me);
+            return GetMe(HttpService.GetNewCancellationToken());
+        }
+        public async Task<Me> GetMe(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<Me>(Links.me, cancellationToken);
         }
 
-        public async Task<ParticipantApplicationSharing> GetParticipantApplicationSharing()
+        public Task<ParticipantApplicationSharing> GetParticipantApplicationSharing()
         {
-            return await HttpService.Get<ParticipantApplicationSharing>(Links.participantApplicationSharing);
+            return GetParticipantApplicationSharing(HttpService.GetNewCancellationToken());
+        }
+        public async Task<ParticipantApplicationSharing> GetParticipantApplicationSharing(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<ParticipantApplicationSharing>(Links.participantApplicationSharing, cancellationToken);
         }
 
-        public async Task<ParticipantAudio> GetParticipantAudio()
+        public Task<ParticipantAudio> GetParticipantAudio()
         {
-            return await HttpService.Get<ParticipantAudio>(Links.participantAudio);
+            return GetParticipantAudio(HttpService.GetNewCancellationToken());
+        }
+        public async Task<ParticipantAudio> GetParticipantAudio(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<ParticipantAudio>(Links.participantAudio, cancellationToken);
         }
 
-        public async Task<ParticipantDataCollaboration> GetParticipantDataCollaboration()
+        public Task<ParticipantDataCollaboration> GetParticipantDataCollaboration()
         {
-            return await HttpService.Get<ParticipantDataCollaboration>(Links.participantDataCollaboration);
+            return GetParticipantDataCollaboration(HttpService.GetNewCancellationToken());
+        }
+        public async Task<ParticipantDataCollaboration> GetParticipantDataCollaboration(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<ParticipantDataCollaboration>(Links.participantDataCollaboration, cancellationToken);
         }
 
-        public async Task<ParticipantMessaging> GetParticipantMessaging()
+        public Task<ParticipantMessaging> GetParticipantMessaging()
         {
-            return await HttpService.Get<ParticipantMessaging>(Links.participantMessaging);
+            return GetParticipantMessaging(HttpService.GetNewCancellationToken());
+        }
+        public async Task<ParticipantMessaging> GetParticipantMessaging(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<ParticipantMessaging>(Links.participantMessaging, cancellationToken);
         }
 
-        public async Task<ParticipantPanoramicVideo> GetParticipantPanoramicVideo()
+        public Task<ParticipantPanoramicVideo> GetParticipantPanoramicVideo()
         {
-            return await HttpService.Get<ParticipantPanoramicVideo>(Links.participantPanoramicVideo);
+            return GetParticipantPanoramicVideo(HttpService.GetNewCancellationToken());
+        }
+        public async Task<ParticipantPanoramicVideo> GetParticipantPanoramicVideo(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<ParticipantPanoramicVideo>(Links.participantPanoramicVideo, cancellationToken);
         }
 
-        public async Task<ParticipantVideo> GetParticipantVideo()
+        public Task<ParticipantVideo> GetParticipantVideo()
         {
-            return await HttpService.Get<ParticipantVideo>(Links.participantVideo);
+            return GetParticipantVideo(HttpService.GetNewCancellationToken());
+        }
+        public async Task<ParticipantVideo> GetParticipantVideo(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<ParticipantVideo>(Links.participantVideo, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/Location.cs
+++ b/UCWASDK/UCWASDK/Models/Location.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -13,9 +14,13 @@ namespace Microsoft.Skype.UCWA.Models
         [JsonProperty("location")]
         public string Address { get; set; }
 
-        public async Task Update()
+        public Task Update()
         {
-            await HttpService.Post(Self, this);
+            return Update(HttpService.GetNewCancellationToken());
+        }
+        public async Task Update(CancellationToken cancellationToken)
+        {
+            await HttpService.Post(Self, this, cancellationToken);
         }
     }   
 }

--- a/UCWASDK/UCWASDK/Models/Me.cs
+++ b/UCWASDK/UCWASDK/Models/Me.cs
@@ -3,6 +3,7 @@ using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -63,47 +64,73 @@ namespace Microsoft.Skype.UCWA.Models
             [JsonProperty("reportMyActivity")]
             internal ReportMyActivity reportMyActivity { get; set; }
         }
+        public Task<Me> Get()
+        {
+            return Get(HttpService.GetNewCancellationToken());
+        }
 
-        public async Task<Me> Get()
+        public async Task<Me> Get(CancellationToken cancellationToken)
         {
             var uri = Self;
-            return await HttpService.Get<Me>(uri);
+            return await HttpService.Get<Me>(uri, cancellationToken);
         }
-
-        public async Task<CallForwardingSettings> GetCallForwardingSettings()
+        public Task<CallForwardingSettings> GetCallForwardingSettings()
         {
-            return await HttpService.Get<CallForwardingSettings>(Links.callForwardingSettings);
+            return GetCallForwardingSettings(HttpService.GetNewCancellationToken());
         }
-
-        public async Task<Location> GetLocation()
+        public async Task<CallForwardingSettings> GetCallForwardingSettings(CancellationToken cancellationToken)
         {
-            return await HttpService.Get<Location>(Links.location);
+            return await HttpService.Get<CallForwardingSettings>(Links.callForwardingSettings, cancellationToken);
         }
-
-        public async Task<Note> GetNote()
+        public Task<Location> GetLocation()
         {
-            return await HttpService.Get<Note>(Links.note);
+            return GetLocation(HttpService.GetNewCancellationToken());
         }
-
-        public async Task<Phone[]> GetPhones()
+        public async Task<Location> GetLocation(CancellationToken cancellationToken)
         {
-            UCWAPhones ucwaPhones = await HttpService.Get<UCWAPhones>(Links.phones);
+            return await HttpService.Get<Location>(Links.location, cancellationToken);
+        }
+        public Task<Note> GetNote()
+        {
+            return GetNote(HttpService.GetNewCancellationToken());
+        }
+        public async Task<Note> GetNote(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<Note>(Links.note, cancellationToken);
+        }
+        public Task<Phone[]> GetPhones()
+        {
+            return GetPhones(HttpService.GetNewCancellationToken());
+        }
+        public async Task<Phone[]> GetPhones(CancellationToken cancellationToken)
+        {
+            UCWAPhones ucwaPhones = await HttpService.Get<UCWAPhones>(Links.phones, cancellationToken);
             if (ucwaPhones == null)
                 ucwaPhones = new UCWAPhones();
             return ucwaPhones.Phones;
         }
-
-        public async Task<byte[]> GetPhoto()
+        public Task<byte[]> GetPhoto()
         {
-            return await HttpService.GetBinary(Links.photo);
+            return GetPhoto(HttpService.GetNewCancellationToken());
+        }
+        public async Task<byte[]> GetPhoto(CancellationToken cancellationToken)
+        {
+            return await HttpService.GetBinary(Links.photo, cancellationToken);
+        }
+        public Task<Presence> GetPresence()
+        {
+            return GetPresence(HttpService.GetNewCancellationToken());
+        }
+        public async Task<Presence> GetPresence(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<Presence>(Links.presence, cancellationToken);
         }
 
-        public async Task<Presence> GetPresencs()
+        public Task MakeMeAvailable(Availability availability, bool supportMessage, bool supportAudio, bool supportPlainText, bool supportHtmlFormat, string phoneNumber)
         {
-            return await HttpService.Get<Presence>(Links.presence);
+            return MakeMeAvailable(availability, supportMessage, supportAudio, supportPlainText, supportHtmlFormat, phoneNumber, HttpService.GetNewCancellationToken());
         }
-
-        public async Task MakeMeAvailable(Availability availability, bool supportMessage, bool supportAudio, bool supportPlainText, bool supportHtmlFormat, string phoneNumber)
+        public async Task MakeMeAvailable(Availability availability, bool supportMessage, bool supportAudio, bool supportPlainText, bool supportHtmlFormat, string phoneNumber, CancellationToken cancellationToken)
         {
             JArray supportedModalities = new JArray();
             JArray supportedMessageFormats = new JArray();
@@ -116,18 +143,24 @@ namespace Microsoft.Skype.UCWA.Models
             if (supportHtmlFormat)
                 supportedMessageFormats.Add(MessageFormat.Html.ToString());
 
-            JObject body = new JObject();
-            body["SupportedModalities"] = supportedModalities;
-            body["SupportedMessageFormats"] = supportedMessageFormats;
-            body["SignInAs"] = availability.ToString();
-            body["phoneNumber"] = phoneNumber;
+            JObject body = new JObject
+            {
+                ["SupportedModalities"] = supportedModalities,
+                ["SupportedMessageFormats"] = supportedMessageFormats,
+                ["SignInAs"] = availability.ToString(),
+                ["phoneNumber"] = phoneNumber
+            };
 
-            await HttpService.Post(Links.makeMeAvailable, body);
+            await HttpService.Post(Links.makeMeAvailable, body, cancellationToken);
         }
 
-        public async Task ReportMyActivity()
+        public Task ReportMyActivity()
         {
-            await HttpService.Post(Links.reportMyActivity, "");
+            return ReportMyActivity(HttpService.GetNewCancellationToken());
+        }
+        public async Task ReportMyActivity(CancellationToken cancellationToken)
+        {
+            await HttpService.Post(Links.reportMyActivity, "", cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/Memberships.cs
+++ b/UCWASDK/UCWASDK/Models/Memberships.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -23,14 +24,18 @@ namespace Microsoft.Skype.UCWA.Models
             internal PresenceSubscriptionMembership presenceSubscriptionMembership { get; set; }               
         }        
 
-        public async Task<PresenceSubscriptionMemberships> Update(string[] contactUris)
+        public Task<PresenceSubscriptionMemberships> Update(string[] contactUris)
         {
-            if (contactUris == null || contactUris.Count() == 0)
+            return Update(contactUris, HttpService.GetNewCancellationToken());
+        }
+        public async Task<PresenceSubscriptionMemberships> Update(string[] contactUris, CancellationToken cancellationToken)
+        {
+            if (contactUris == null || !contactUris.Any())
                 return null;
 
             JObject body = new JObject();
             body["contactUris"] = new JArray(contactUris);
-            return await HttpService.Post<PresenceSubscriptionMemberships>(Self, body);
+            return await HttpService.Post<PresenceSubscriptionMemberships>(Self, body, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/Message.cs
+++ b/UCWASDK/UCWASDK/Models/Message.cs
@@ -78,14 +78,22 @@ namespace Microsoft.Skype.UCWA.Models
             internal UCWAHref participant { get; set; }
         }
         
-        public async Task<Contact> GetContact()
+        public Task<Contact> GetContact()
         {
-            return await HttpService.Get<Contact>(Links.contact);
+            return GetContact(HttpService.GetNewCancellationToken());
+        }
+        public async Task<Contact> GetContact(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<Contact>(Links.contact, cancellationToken);
         }
 
-        public async Task<List<FailedDeliveryParticipant>> GetFailedDeliveryParticipants()
+        public Task<List<FailedDeliveryParticipant>> GetFailedDeliveryParticipants()
         {
-            return await HttpService.GetList<FailedDeliveryParticipant>(Links.failedDeliveryParticipant);
+            return GetFailedDeliveryParticipants(HttpService.GetNewCancellationToken());
+        }
+        public async Task<List<FailedDeliveryParticipant>> GetFailedDeliveryParticipants(CancellationToken cancellationToken)
+        {
+            return await HttpService.GetList<FailedDeliveryParticipant>(Links.failedDeliveryParticipant, cancellationToken);
         }
 
         public Task<Messaging> GetMessaging()
@@ -97,9 +105,13 @@ namespace Microsoft.Skype.UCWA.Models
             return await HttpService.Get<Messaging>(Links.messaging, cancellationToken);
         }
 
-        public async Task<Participant> GetParticipant()
+        public Task<Participant> GetParticipant()
         {
-            return await HttpService.Get<Participant>(Links.participant);
+            return GetParticipant(HttpService.GetNewCancellationToken());
+        }
+        public async Task<Participant> GetParticipant(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<Participant>(Links.participant, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/Message.cs
+++ b/UCWASDK/UCWASDK/Models/Message.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 
@@ -87,9 +88,13 @@ namespace Microsoft.Skype.UCWA.Models
             return await HttpService.GetList<FailedDeliveryParticipant>(Links.failedDeliveryParticipant);
         }
 
-        public async Task<Messaging> GetMessaging()
+        public Task<Messaging> GetMessaging()
         {
-            return await HttpService.Get<Messaging>(Links.messaging);
+            return GetMessaging(HttpService.GetNewCancellationToken());
+        }
+        public async Task<Messaging> GetMessaging(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<Messaging>(Links.messaging, cancellationToken);
         }
 
         public async Task<Participant> GetParticipant()

--- a/UCWASDK/UCWASDK/Models/Messaging.cs
+++ b/UCWASDK/UCWASDK/Models/Messaging.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Skype.UCWA.Models
 
         [JsonProperty("state")]
         public string State { get; internal set; }
-        
+
         [JsonProperty("_links")]
         internal InternalLinks Links { get; set; }
 
@@ -32,21 +32,21 @@ namespace Microsoft.Skype.UCWA.Models
             internal UCWAHref self { get; set; }
 
             [JsonProperty("addMessaging")]
-            internal AddMessaging addMessaging { get; set; }           
-     
+            internal AddMessaging addMessaging { get; set; }
+
             [JsonProperty("conversation")]
             internal UCWAHref conversation { get; set; }
-            
+
             [JsonProperty("sendMessage")]
             internal SendMessage sendMessage { get; set; }
             public string SendMessage { get { return sendMessage?.Href; } }
 
             [JsonProperty("setIsTyping")]
             internal SetIsTyping setIsTyping { get; set; }
-     
+
             [JsonProperty("stopMessaging")]
             internal StopMessaging stopMessaging { get; set; }
-     
+
             [JsonProperty("typingParticipants")]
             internal UCWAHref typingParticipants { get; set; }
         }
@@ -91,27 +91,43 @@ namespace Microsoft.Skype.UCWA.Models
             return await HttpService.Get<Conversation>(Links.conversation, cancellationToken);
         }
 
-        public async Task SendMessage(string message)
+        public Task SendMessage(string message)
+        {
+            return SendMessage(message, HttpService.GetNewCancellationToken());
+        }
+        public Task SendMessage(string message, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(message))
-                return;
-            
-            await HttpService.Post(Links.SendMessage, message);
+                return Task.FromResult<object>(null);
+
+            return HttpService.Post(Links.SendMessage, message, cancellationToken);
         }
 
-        public async Task StopMessaging()
+        public Task StopMessaging()
         {
-            await HttpService.Post(Links.stopMessaging, "");
+            return StopMessaging(HttpService.GetNewCancellationToken());
+        }
+        public Task StopMessaging(CancellationToken cancellationToken)
+        {
+            return HttpService.Post(Links.stopMessaging, "", cancellationToken);
         }
 
-        public async Task SetIsTyping()
+        public Task SetIsTyping()
         {
-            await HttpService.Post(Links.setIsTyping, "");
+            return SetIsTyping(HttpService.GetNewCancellationToken());
+        }
+        public Task SetIsTyping(CancellationToken cancellationToken)
+        {
+            return HttpService.Post(Links.setIsTyping, "", cancellationToken);
         }
 
-        public async Task<TypingParticipants> GetTypingParticipants()
+        public Task<TypingParticipants> GetTypingParticipants()
         {
-            return await HttpService.Get<TypingParticipants>(Links.typingParticipants);
+            return GetTypingParticipants(HttpService.GetNewCancellationToken());
+        }
+        public Task<TypingParticipants> GetTypingParticipants(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<TypingParticipants>(Links.typingParticipants, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/Messaging.cs
+++ b/UCWASDK/UCWASDK/Models/Messaging.cs
@@ -51,7 +51,11 @@ namespace Microsoft.Skype.UCWA.Models
             internal UCWAHref typingParticipants { get; set; }
         }
 
-        public async Task AddMessaging(MessageFormat messageFormat, string message)
+        public Task AddMessaging(MessageFormat messageFormat, string message)
+        {
+            return AddMessaging(messageFormat, message, HttpService.GetNewCancellationToken());
+        }
+        public async Task AddMessaging(MessageFormat messageFormat, string message, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(message))
                 return;
@@ -75,7 +79,7 @@ namespace Microsoft.Skype.UCWA.Models
                 }
             };
 
-            await HttpService.Post(Links.addMessaging, messagingInvitation);
+            await HttpService.Post(Links.addMessaging, messagingInvitation, cancellationToken);
         }
 
         public Task<Conversation> GetConversation()

--- a/UCWASDK/UCWASDK/Models/Messaging.cs
+++ b/UCWASDK/UCWASDK/Models/Messaging.cs
@@ -3,6 +3,7 @@ using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -77,9 +78,13 @@ namespace Microsoft.Skype.UCWA.Models
             await HttpService.Post(Links.addMessaging, messagingInvitation);
         }
 
-        public async Task<Conversation> GetConversation()
+        public Task<Conversation> GetConversation()
         {
-            return await HttpService.Get<Conversation>(Links.conversation);
+            return GetConversation(HttpService.GetNewCancellationToken());
+        }
+        public async Task<Conversation> GetConversation(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<Conversation>(Links.conversation, cancellationToken);
         }
 
         public async Task SendMessage(string message)

--- a/UCWASDK/UCWASDK/Models/MessagingInvitation.cs
+++ b/UCWASDK/UCWASDK/Models/MessagingInvitation.cs
@@ -2,6 +2,7 @@
 using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -120,9 +121,13 @@ namespace Microsoft.Skype.UCWA.Models
             await HttpService.Post(Links.cancel, "");
         }
 
-        public async Task<Conversation> GetConversation()
+        public Task<Conversation> GetConversation()
         {
-            return await HttpService.Get<Conversation>(Links.conversation);
+            return GetConversation(HttpService.GetNewCancellationToken());
+        }
+        public async Task<Conversation> GetConversation(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<Conversation>(Links.conversation, cancellationToken);
         }
 
         public async Task Decline(CallDeclineReason reason)

--- a/UCWASDK/UCWASDK/Models/MessagingInvitation.cs
+++ b/UCWASDK/UCWASDK/Models/MessagingInvitation.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Skype.UCWA.Models
 
             [JsonProperty("customContent")]
             internal UCWAHref customContent { get; set; }
-            
+
             [JsonProperty("message")]
             internal UCWAHref message { get; set; }
 
@@ -105,63 +105,99 @@ namespace Microsoft.Skype.UCWA.Models
             [JsonProperty("from")]
             internal Participant from { get; set; }
         }
-        
-        public async Task Accept()
+
+        public Task Accept()
         {
-            await HttpService.Post(Links.accept, "");
+            return Accept(HttpService.GetNewCancellationToken());
+        }
+        public Task Accept(CancellationToken cancellationToken)
+        {
+            return HttpService.Post(Links.accept, "", cancellationToken);
         }
 
-        public async Task<AcceptedByContact> GetAcceptedByContact()
+        public Task<AcceptedByContact> GetAcceptedByContact()
         {
-            return await HttpService.Get<AcceptedByContact>(Links.acceptedByContact);
+            return GetAcceptedByContact(HttpService.GetNewCancellationToken());
+        }
+        public Task<AcceptedByContact> GetAcceptedByContact(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<AcceptedByContact>(Links.acceptedByContact, cancellationToken);
         }
 
-        public async Task Cancel()
+        public Task Cancel()
         {
-            await HttpService.Post(Links.cancel, "");
+            return Cancel(HttpService.GetNewCancellationToken());
+        }
+        public Task Cancel(CancellationToken cancellationToken)
+        {
+            return HttpService.Post(Links.cancel, "", cancellationToken);
         }
 
         public Task<Conversation> GetConversation()
         {
             return GetConversation(HttpService.GetNewCancellationToken());
         }
-        public async Task<Conversation> GetConversation(CancellationToken cancellationToken)
+        public Task<Conversation> GetConversation(CancellationToken cancellationToken)
         {
-            return await HttpService.Get<Conversation>(Links.conversation, cancellationToken);
+            return HttpService.Get<Conversation>(Links.conversation, cancellationToken);
         }
 
-        public async Task Decline(CallDeclineReason reason)
+        public Task Decline(CallDeclineReason reason)
+        {
+            return Decline(reason, HttpService.GetNewCancellationToken());
+        }
+        public Task Decline(CallDeclineReason reason, CancellationToken cancellationToken)
         {
             CallDecline callDecline = new CallDecline()
             {
                 Reason = reason
             };
-            await HttpService.Post(Links.decline, callDecline);
+            return HttpService.Post(Links.decline, callDecline, cancellationToken);
         }
 
-        public async Task<From> GetFrom()
+        public Task<From> GetFrom()
         {
-            return await HttpService.Get<From>(Links.from);
+            return GetFrom(HttpService.GetNewCancellationToken());
+        }
+        public Task<From> GetFrom(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<From>(Links.from, cancellationToken);
         }
 
-        public async Task<DerivedMessaging> GetDerivedMessaging()
+        public Task<DerivedMessaging> GetDerivedMessaging()
         {
-            return await HttpService.Get<DerivedMessaging>(Links.derivedMessaging);
+            return GetDerivedMessaging(HttpService.GetNewCancellationToken());
+        }
+        public Task<DerivedMessaging> GetDerivedMessaging(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<DerivedMessaging>(Links.derivedMessaging, cancellationToken);
         }
 
-        public async Task<Messaging> GetMessaging()
+        public Task<Messaging> GetMessaging()
         {
-            return await HttpService.Get<Messaging>(Links.messaging);
+            return GetMessaging(HttpService.GetNewCancellationToken());
+        }
+        public Task<Messaging> GetMessaging(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<Messaging>(Links.messaging, cancellationToken);
         }
 
-        public async Task<OnBehalfOf> GetOnBehalfOf()
+        public Task<OnBehalfOf> GetOnBehalfOf()
         {
-            return await HttpService.Get<OnBehalfOf>(Links.onBehalfOf);
+            return GetOnBehalfOf(HttpService.GetNewCancellationToken());
+        }
+        public Task<OnBehalfOf> GetOnBehalfOf(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<OnBehalfOf>(Links.onBehalfOf, cancellationToken);
         }
 
-        public async Task<To> GetTo()
+        public Task<To> GetTo()
         {
-            return await HttpService.Get<To>(Links.to);
+            return GetTo(HttpService.GetNewCancellationToken());
+        }
+        public Task<To> GetTo(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<To>(Links.to, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/MyContacts.cs
+++ b/UCWASDK/UCWASDK/Models/MyContacts.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -38,9 +39,13 @@ namespace Microsoft.Skype.UCWA.Models
             internal Contact[] contacts { get; set; }
         }
 
-        public async Task<List<Contact>> GetContacts()
+        public Task<List<Contact>> GetContacts()
         {
-            return await HttpService.GetList<Contact>(Links.contact);
+            return GetContacts(HttpService.GetNewCancellationToken());
+        }
+        public Task<List<Contact>> GetContacts(CancellationToken cancellationToken)
+        {
+            return HttpService.GetList<Contact>(Links.contact, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/MyContactsAndGroupsSubscription.cs
+++ b/UCWASDK/UCWASDK/Models/MyContactsAndGroupsSubscription.cs
@@ -2,6 +2,7 @@
 using Microsoft.Skype.UCWA.Enums;
 using Newtonsoft.Json;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace Microsoft.Skype.UCWA.Models
 {
@@ -13,7 +14,7 @@ namespace Microsoft.Skype.UCWA.Models
     {
         [JsonProperty("state")]
         public SubscriptionState State { get; internal set; }
-        
+
         [JsonProperty("_links")]
         internal InternalLinks Links { get; set; }
 
@@ -32,18 +33,26 @@ namespace Microsoft.Skype.UCWA.Models
             internal StopSubscriptionToContactsAndGroups stopSubscriptionToContactsAndGroups { get; set; }
         }
 
-        public async Task StartOrRefreshSubscriptionToContactsAndGroups(int duration)
+        public Task StartOrRefreshSubscriptionToContactsAndGroups(int duration)
+        {
+            return StartOrRefreshSubscriptionToContactsAndGroups(duration, HttpService.GetNewCancellationToken());
+        }
+        public Task StartOrRefreshSubscriptionToContactsAndGroups(int duration, CancellationToken cancellationToken)
         {
             if (duration > 60 && duration < 10)
-                return;
+                return Task.FromResult<object>(null);
 
             var uri = Links.startOrRefreshSubscriptionToContactsAndGroups.Href + "?duration=" + duration;
-            await HttpService.Post(uri, "");
+            return HttpService.Post(uri, "", cancellationToken);
         }
 
-        public async Task StopSubscriptionToContactsAndGroups()
+        public Task StopSubscriptionToContactsAndGroups()
         {
-            await HttpService.Post(Links.stopSubscriptionToContactsAndGroups, "");
+            return StopSubscriptionToContactsAndGroups(HttpService.GetNewCancellationToken());
+        }
+        public Task StopSubscriptionToContactsAndGroups(CancellationToken cancellationToken)
+        {
+            return HttpService.Post(Links.stopSubscriptionToContactsAndGroups, "", cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/MyGroupMembership.cs
+++ b/UCWASDK/UCWASDK/Models/MyGroupMembership.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -9,7 +10,7 @@ namespace Microsoft.Skype.UCWA.Models
     /// This resource captures a unique pair of contact and group. If a contact appears in multiple groups, there will be a separate resource for each membership of this contact. 
     /// </summary>
     public class MyGroupMembership : UCWAModelBase
-    {        
+    {
         [JsonProperty("_links")]
         internal InternalLinks Links { get; set; }
 
@@ -23,35 +24,51 @@ namespace Microsoft.Skype.UCWA.Models
 
             [JsonProperty("contact")]
             internal UCWAHref contact { get; set; }
-   
+
             [JsonProperty("defaultGroup")]
             internal UCWAHref defaultGroup { get; set; }
-   
+
             [JsonProperty("group")]
             internal UCWAHref group { get; set; }
-   
+
             [JsonProperty("pinnedGroup")]
             internal UCWAHref pinnedGroup { get; set; }
         }
 
-        public async Task<Contact> GetContact()
+        public Task<Contact> GetContact()
         {
-            return await HttpService.Get<Contact>(Links.contact);
+            return GetContact(HttpService.GetNewCancellationToken());
+        }
+        public Task<Contact> GetContact(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<Contact>(Links.contact, cancellationToken);
         }
 
-        public async Task<DefaultGroup> GetDefaultGroup()
+        public Task<DefaultGroup> GetDefaultGroup()
         {
-            return await HttpService.Get<DefaultGroup>(Links.defaultGroup);
+            return GetDefaultGroup(HttpService.GetNewCancellationToken());
+        }
+        public Task<DefaultGroup> GetDefaultGroup(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<DefaultGroup>(Links.defaultGroup, cancellationToken);
         }
 
-        public async Task<Group> GetGroup()
+        public Task<Group> GetGroup()
         {
-            return await HttpService.Get<Group>(Links.group);
+            return GetGroup(HttpService.GetNewCancellationToken());
+        }
+        public Task<Group> GetGroup(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<Group>(Links.group, cancellationToken);
         }
 
-        public async Task<PinnedGroup> GetPinnedGroup()
+        public Task<PinnedGroup> GetPinnedGroup()
         {
-            return await HttpService.Get<PinnedGroup>(Links.pinnedGroup);
+            return GetPinnedGroup(HttpService.GetNewCancellationToken());
+        }
+        public Task<PinnedGroup> GetPinnedGroup(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<PinnedGroup>(Links.pinnedGroup, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/MyGroupMembership2.cs
+++ b/UCWASDK/UCWASDK/Models/MyGroupMembership2.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Skype.UCWA.Services;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -9,9 +10,13 @@ namespace Microsoft.Skype.UCWA.Models
     /// </summary>
     public class MyGroupMembership2 : MyGroupMembership
     {        
-        public async Task Delete()
+        public Task Delete()
         {
-            await HttpService.Delete(Self, "2");
+            return Delete(HttpService.GetNewCancellationToken());
+        }
+        public Task Delete(CancellationToken cancellationToken)
+        {
+            return HttpService.Delete(Self, cancellationToken, "2");
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/MyGroupMemberships2.cs
+++ b/UCWASDK/UCWASDK/Models/MyGroupMemberships2.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -9,7 +10,7 @@ namespace Microsoft.Skype.UCWA.Models
     /// The version two supports adding single contact to a particular group and removing a contact from the buddy list (all groups associated) 
     /// </summary>
     public class MyGroupMemberships2 : UCWAModelBase
-    {        
+    {
         [JsonProperty("_links")]
         internal InternalLinks Links { get; set; }
 
@@ -37,24 +38,32 @@ namespace Microsoft.Skype.UCWA.Models
             internal MyGroupMembership2[] groupMembership { get; set; }
         }
 
-        public async Task AddContact(string sipName, string groupId)
+        public Task AddContact(string sipName, string groupId)
+        {
+            return AddContact(sipName, groupId, HttpService.GetNewCancellationToken());
+        }
+        public Task AddContact(string sipName, string groupId, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(sipName) || string.IsNullOrEmpty(groupId))
-                return;
+                return Task.FromResult<object>(null);
 
             var uri = Self + "?contactUri=" + sipName + "&groupId=" + groupId;
 
-            await HttpService.Post(uri, "", "2");
+            return HttpService.Post(uri, "", cancellationToken, "2");
         }
 
-        public async Task RemoveContactFromAllGroups(string sipName)
+        public Task RemoveContactFromAllGroups(string sipName)
+        {
+            return RemoveContactFromAllGroups(sipName, HttpService.GetNewCancellationToken());
+        }
+        public Task RemoveContactFromAllGroups(string sipName, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(sipName))
-                return;
-            
+                return Task.FromResult<object>(null);
+
             var uri = Links.removeContactFromAllGroups.Href + "?contactUri=" + sipName;
 
-            await HttpService.Post(uri, "", "2");
+            return HttpService.Post(uri, "", cancellationToken, "2");
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/MyGroups2.cs
+++ b/UCWASDK/UCWASDK/Models/MyGroups2.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -41,14 +42,18 @@ namespace Microsoft.Skype.UCWA.Models
             internal DistributionGroup[] distributionGroups { get; set; }
         }
 
-        public async Task CreateGroup(string displayName)
+        public Task CreateGroup(string displayName)
+        {
+            return CreateGroup(displayName, HttpService.GetNewCancellationToken());
+        }
+        public Task CreateGroup(string displayName, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(displayName))
-                return;
+                return Task.FromResult<object>(null);
 
             JObject body = new JObject();
             body["displayName"] = displayName;
-            await HttpService.Post(Self, body, "2");
+            return HttpService.Post(Self, body, cancellationToken, "2");
         }
     }    
 }

--- a/UCWASDK/UCWASDK/Models/MyOnlineMeeting.cs
+++ b/UCWASDK/UCWASDK/Models/MyOnlineMeeting.cs
@@ -2,6 +2,7 @@
 using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -87,24 +88,41 @@ namespace Microsoft.Skype.UCWA.Models
             internal OnlineMeetingExtension[] onlineMeetingExtensions { get; set; }               
         }
 
-        public async Task<OnlineMeetingExtensions> GetOnlineMeetingExtensions()
+        public Task<OnlineMeetingExtensions> GetOnlineMeetingExtensions()
         {
-            return await HttpService.Get<OnlineMeetingExtensions>(Links.onlineMeetingExtensions);
+            return GetOnlineMeetingExtensions(HttpService.GetNewCancellationToken());
+        }
+        public async Task<OnlineMeetingExtensions> GetOnlineMeetingExtensions(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<OnlineMeetingExtensions>(Links.onlineMeetingExtensions, cancellationToken);
         }
 
-        public async Task<MyOnlineMeeting> Get()
+        public Task<MyOnlineMeeting> Get()
         {
-            return await HttpService.Get<MyOnlineMeeting>(Self);
+            return Get(HttpService.GetNewCancellationToken());
         }
 
-        public async Task Delete()
+        public async Task<MyOnlineMeeting> Get(CancellationToken cancellationToken)
         {
-            await HttpService.Delete(Self);
+            return await HttpService.Get<MyOnlineMeeting>(Self, cancellationToken);
         }
 
-        public async Task<MyOnlineMeeting> Update()
+        public Task Delete()
         {
-            return await HttpService.Put<MyOnlineMeeting>(Self, this);
+            return Delete(HttpService.GetNewCancellationToken());
+        }
+        public async Task Delete(CancellationToken cancellationToken)
+        {
+            await HttpService.Delete(Self, cancellationToken);
+        }
+
+        public Task<MyOnlineMeeting> Update()
+        {
+            return Update(HttpService.GetNewCancellationToken());
+        }
+        public async Task<MyOnlineMeeting> Update(CancellationToken cancellationToken)
+        {
+            return await HttpService.Put<MyOnlineMeeting>(Self, this, cancellationToken);
         }      
     }
 }

--- a/UCWASDK/UCWASDK/Models/MyOnlineMeetings.cs
+++ b/UCWASDK/UCWASDK/Models/MyOnlineMeetings.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -28,9 +29,13 @@ namespace Microsoft.Skype.UCWA.Models
             internal MyOnlineMeeting[] onlineMeetings { get; set; } = new MyOnlineMeeting[0];
         }
 
-        public async Task<MyOnlineMeeting> Create(MyOnlineMeeting meeting)
+        public Task<MyOnlineMeeting> Create(MyOnlineMeeting meeting)
         {
-            return await HttpService.Post<MyOnlineMeeting>(Self, meeting);
+            return Create(meeting, HttpService.GetNewCancellationToken());
+        }
+        public Task<MyOnlineMeeting> Create(MyOnlineMeeting meeting, CancellationToken cancellationToken)
+        {
+            return HttpService.Post<MyOnlineMeeting>(Self, meeting, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/MyPrivacyRelationship.cs
+++ b/UCWASDK/UCWASDK/Models/MyPrivacyRelationship.cs
@@ -2,6 +2,7 @@
 using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -30,9 +31,13 @@ namespace Microsoft.Skype.UCWA.Models
             internal UCWAHref[] contact { get; set; }
         }
 
-        public async Task<List<Contact>> GetContacts()
+        public Task<List<Contact>> GetContacts()
         {
-            return await HttpService.GetList<Contact>(Links.contact);
+            return GetContacts(HttpService.GetNewCancellationToken());
+        }
+        public Task<List<Contact>> GetContacts(CancellationToken cancellationToken)
+        {
+            return HttpService.GetList<Contact>(Links.contact, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/NextConversationLogTranscripts.cs
+++ b/UCWASDK/UCWASDK/Models/NextConversationLogTranscripts.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -36,9 +37,13 @@ namespace Microsoft.Skype.UCWA.Models
             internal ConversationLogTranscript[] conversationLogTranscripts { get; set; }               
         }
 
-        public async Task<NextConversationLogTranscripts> GetNextConversationLogTranscripts()
+        public Task<NextConversationLogTranscripts> GetNextConversationLogTranscripts()
         {
-            return await HttpService.Get<NextConversationLogTranscripts>(Links.nextConversationLogTranscripts);
+            return GetNextConversationLogTranscripts(HttpService.GetNewCancellationToken());
+        }
+        public Task<NextConversationLogTranscripts> GetNextConversationLogTranscripts(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<NextConversationLogTranscripts>(Links.nextConversationLogTranscripts, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/Note.cs
+++ b/UCWASDK/UCWASDK/Models/Note.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Skype.UCWA.Enums;
 using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -17,9 +18,13 @@ namespace Microsoft.Skype.UCWA.Models
         [JsonProperty("type")]
         public NoteType Type { get; set; }
 
-        public async Task Update()
+        public Task Update()
         {
-            await HttpService.Post(Self, this);
+            return Update(HttpService.GetNewCancellationToken());
+        }
+        public Task Update(CancellationToken cancellationToken)
+        {
+            return HttpService.Post(Self, this, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/OnlineMeetingEligibleValues.cs
+++ b/UCWASDK/UCWASDK/Models/OnlineMeetingEligibleValues.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Skype.UCWA.Enums;
 using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -38,19 +39,27 @@ namespace Microsoft.Skype.UCWA.Models
 
             [JsonProperty("myAssignedOnlineMeeting")]
             internal UCWAHref myAssignedOnlineMeeting { get; set; }
-            
+
             [JsonProperty("myOnlineMeetings")]
             internal UCWAHref myOnlineMeetings { get; set; }
-         }
-
-        public async Task<MyAssignedOnlineMeeting> GetMyAssignedOnlineMeeting()
-        {
-            return await HttpService.Get<MyAssignedOnlineMeeting>(Links.myAssignedOnlineMeeting);
         }
 
-        public async Task<MyOnlineMeetings> GetMyOnlineMeetings()
+        public Task<MyAssignedOnlineMeeting> GetMyAssignedOnlineMeeting()
         {
-            return await HttpService.Get<MyOnlineMeetings>(Links.myOnlineMeetings);
+            return GetMyAssignedOnlineMeeting(HttpService.GetNewCancellationToken());
+        }
+        public Task<MyAssignedOnlineMeeting> GetMyAssignedOnlineMeeting(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<MyAssignedOnlineMeeting>(Links.myAssignedOnlineMeeting, cancellationToken);
+        }
+
+        public Task<MyOnlineMeetings> GetMyOnlineMeetings()
+        {
+            return GetMyOnlineMeetings(HttpService.GetNewCancellationToken());
+        }
+        public Task<MyOnlineMeetings> GetMyOnlineMeetings(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<MyOnlineMeetings>(Links.myOnlineMeetings, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/OnlineMeetingExtension.cs
+++ b/UCWASDK/UCWASDK/Models/OnlineMeetingExtension.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Net.Http;
 using Newtonsoft.Json.Linq;
+using System.Threading;
 
 namespace Microsoft.Skype.UCWA.Models
 {
@@ -23,14 +24,22 @@ namespace Microsoft.Skype.UCWA.Models
         [JsonProperty("type")]
         public OnlineMeetingExtensionType Type { get; set; }
 
-        public async Task Update()
+        public Task Update()
         {
-            await HttpService.Put(Self, this);
+            return Update(HttpService.GetNewCancellationToken());
+        }
+        public Task Update(CancellationToken cancellationToken)
+        {
+            return HttpService.Put(Self, this, cancellationToken);
         }
 
-        public async Task Delete()
+        public Task Delete()
         {
-            await HttpService.Delete(Self);
+            return Delete(HttpService.GetNewCancellationToken());
+        }
+        public Task Delete(CancellationToken cancellationToken)
+        {
+            return HttpService.Delete(Self, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/OnlineMeetingExtensions.cs
+++ b/UCWASDK/UCWASDK/Models/OnlineMeetingExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -20,9 +21,13 @@ namespace Microsoft.Skype.UCWA.Models
             internal OnlineMeetingExtension[] meetingExtensions { get; set; }               
         }
 
-        public async Task<OnlineMeetingExtension> Create(OnlineMeetingExtension onlineMeetingExtension)
+        public Task<OnlineMeetingExtension> Create(OnlineMeetingExtension onlineMeetingExtension)
         {
-            return await HttpService.Post<OnlineMeetingExtension>(Self, onlineMeetingExtension);
+            return Create(onlineMeetingExtension, HttpService.GetNewCancellationToken());
+        }
+        public Task<OnlineMeetingExtension> Create(OnlineMeetingExtension onlineMeetingExtension, CancellationToken cancellationToken)
+        {
+            return HttpService.Post<OnlineMeetingExtension>(Self, onlineMeetingExtension, cancellationToken);
         }        
     }
 }

--- a/UCWASDK/UCWASDK/Models/OnlineMeetingInvitation.cs
+++ b/UCWASDK/UCWASDK/Models/OnlineMeetingInvitation.cs
@@ -2,6 +2,7 @@
 using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -118,9 +119,13 @@ namespace Microsoft.Skype.UCWA.Models
             await HttpService.Post(Links.cancel, "");
         }
 
-        public async Task<Conversation> GetConversation()
+        public Task<Conversation> GetConversation()
         {
-            return await HttpService.Get<Conversation>(Links.conversation);
+            return GetConversation(HttpService.GetNewCancellationToken());
+        }
+        public async Task<Conversation> GetConversation(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<Conversation>(Links.conversation, cancellationToken);
         }
 
         public async Task Decline(CallDeclineReason reason)

--- a/UCWASDK/UCWASDK/Models/OnlineMeetingInvitation.cs
+++ b/UCWASDK/UCWASDK/Models/OnlineMeetingInvitation.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Skype.UCWA.Models
         public string CustomContent { get { return Links.customContent == null ? "" : WebUtility.UrlDecode(Links.customContent.Href.Split(',')[1]); } }
 
         [JsonIgnore]
-        public string Message { get { return Links.message == null ? "" :  WebUtility.UrlDecode(Links.message.Href.Split(',')[1]); } }
+        public string Message { get { return Links.message == null ? "" : WebUtility.UrlDecode(Links.message.Href.Split(',')[1]); } }
 
 
         [JsonProperty("_embedded")]
@@ -68,32 +68,32 @@ namespace Microsoft.Skype.UCWA.Models
             internal UCWAHref self { get; set; }
 
             [JsonProperty("customContent")]
-            internal UCWAHref customContent { get; set; }            
+            internal UCWAHref customContent { get; set; }
 
             [JsonProperty("message")]
             internal UCWAHref message { get; set; }
-            
+
             [JsonProperty("from")]
             internal UCWAHref from { get; set; }
-  
+
             [JsonProperty("accept")]
             internal Accept accept { get; set; }
-  
+
             [JsonProperty("acceptedByContact")]
             internal UCWAHref acceptedByContact { get; set; }
-  
+
             [JsonProperty("cancel")]
             internal Cancel cancel { get; set; }
-  
+
             [JsonProperty("conversation")]
             internal UCWAHref conversation { get; set; }
-  
+
             [JsonProperty("decline")]
             internal UCWAHref decline { get; set; }
-  
+
             [JsonProperty("onBehalfOf")]
             internal UCWAHref onBehalfOf { get; set; }
-  
+
             [JsonProperty("to")]
             internal UCWAHref to { get; set; }
         }
@@ -101,55 +101,83 @@ namespace Microsoft.Skype.UCWA.Models
         internal class InternalEmbedded
         {
             [JsonProperty("from")]
-            internal From from { get; set; }               
+            internal From from { get; set; }
         }
 
-        public async Task Accept()
+        public Task Accept()
         {
-            await HttpService.Post(Links.accept, "");
+            return Accept(HttpService.GetNewCancellationToken());
+        }
+        public Task Accept(CancellationToken cancellationToken)
+        {
+            return HttpService.Post(Links.accept, "", cancellationToken);
         }
 
-        public async Task<AcceptedByContact> GetAcceptedByContact()
+        public Task<AcceptedByContact> GetAcceptedByContact()
         {
-            return await HttpService.Get<AcceptedByContact>(Links.acceptedByContact);
+            return GetAcceptedByContact(HttpService.GetNewCancellationToken());
+        }
+        public Task<AcceptedByContact> GetAcceptedByContact(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<AcceptedByContact>(Links.acceptedByContact, cancellationToken);
         }
 
-        public async Task Cancel()
+        public Task Cancel()
         {
-            await HttpService.Post(Links.cancel, "");
+            return Cancel(HttpService.GetNewCancellationToken());
+        }
+        public Task Cancel(CancellationToken cancellationToken)
+        {
+            return HttpService.Post(Links.cancel, "", cancellationToken);
         }
 
         public Task<Conversation> GetConversation()
         {
             return GetConversation(HttpService.GetNewCancellationToken());
         }
-        public async Task<Conversation> GetConversation(CancellationToken cancellationToken)
+        public Task<Conversation> GetConversation(CancellationToken cancellationToken)
         {
-            return await HttpService.Get<Conversation>(Links.conversation, cancellationToken);
+            return HttpService.Get<Conversation>(Links.conversation, cancellationToken);
         }
 
-        public async Task Decline(CallDeclineReason reason)
+        public Task Decline(CallDeclineReason reason)
+        {
+            return Decline(reason, HttpService.GetNewCancellationToken());
+        }
+        public Task Decline(CallDeclineReason reason, CancellationToken cancellationToken)
         {
             CallDecline callDecline = new CallDecline()
             {
-                 Reason = reason
+                Reason = reason
             };
-            await HttpService.Post(Links.decline, callDecline);
-        }
-        
-        public async Task<From> GetFrom()
-        {
-            return await HttpService.Get<From>(Links.from);
+            return HttpService.Post(Links.decline, callDecline, cancellationToken);
         }
 
-        public async Task<OnBehalfOf> GetOnBehalfOf()
+        public Task<From> GetFrom()
         {
-            return await HttpService.Get<OnBehalfOf>(Links.onBehalfOf);
+            return GetFrom(HttpService.GetNewCancellationToken());
+        }
+        public Task<From> GetFrom(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<From>(Links.from, cancellationToken);
         }
 
-        public async Task<To> GetTo()
+        public Task<OnBehalfOf> GetOnBehalfOf()
         {
-            return await HttpService.Get<To>(Links.to);
+            return GetOnBehalfOf(HttpService.GetNewCancellationToken());
+        }
+        public Task<OnBehalfOf> GetOnBehalfOf(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<OnBehalfOf>(Links.onBehalfOf, cancellationToken);
+        }
+
+        public Task<To> GetTo()
+        {
+            return GetTo(HttpService.GetNewCancellationToken());
+        }
+        public Task<To> GetTo(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<To>(Links.to, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/OnlineMeetings.cs
+++ b/UCWASDK/UCWASDK/Models/OnlineMeetings.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -23,59 +24,87 @@ namespace Microsoft.Skype.UCWA.Models
 
             [JsonProperty("myAssignedOnlineMeeting")]
             internal UCWAHref myAssignedOnlineMeeting { get; set; }
-      
+
             [JsonProperty("myOnlineMeetings")]
             internal UCWAHref myOnlineMeetings { get; set; }
-      
+
             [JsonProperty("onlineMeetingDefaultValues")]
             internal UCWAHref onlineMeetingDefaultValues { get; set; }
-      
+
             [JsonProperty("onlineMeetingEligibleValues")]
             internal UCWAHref onlineMeetingEligibleValues { get; set; }
-      
+
             [JsonProperty("onlineMeetingInvitationCustomization")]
             internal UCWAHref onlineMeetingInvitationCustomization { get; set; }
-      
+
             [JsonProperty("onlineMeetingPolicies")]
             internal UCWAHref onlineMeetingPolicies { get; set; }
-      
+
             [JsonProperty("phoneDialInInformation")]
             internal UCWAHref phoneDialInInformation { get; set; }
         }
 
-        public async Task<MyAssignedOnlineMeeting> GetMyAssignedOnlineMeeting()
+        public Task<MyAssignedOnlineMeeting> GetMyAssignedOnlineMeeting()
         {
-            return await HttpService.Get<MyAssignedOnlineMeeting>(Links.myAssignedOnlineMeeting);
+            return GetMyAssignedOnlineMeeting(HttpService.GetNewCancellationToken());
+        }
+        public Task<MyAssignedOnlineMeeting> GetMyAssignedOnlineMeeting(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<MyAssignedOnlineMeeting>(Links.myAssignedOnlineMeeting, cancellationToken);
         }
 
-        public async Task<MyOnlineMeetings> GetMyOnlineMeetings()
+        public Task<MyOnlineMeetings> GetMyOnlineMeetings()
         {
-            return await HttpService.Get<MyOnlineMeetings>(Links.myOnlineMeetings);
+            return GetMyOnlineMeetings(HttpService.GetNewCancellationToken());
+        }
+        public Task<MyOnlineMeetings> GetMyOnlineMeetings(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<MyOnlineMeetings>(Links.myOnlineMeetings, cancellationToken);
         }
 
-        public async Task<OnlineMeetingDefaultValues> GetOnlineMeetingDefaultValues()
+        public Task<OnlineMeetingDefaultValues> GetOnlineMeetingDefaultValues()
         {
-            return await HttpService.Get<OnlineMeetingDefaultValues>(Links.onlineMeetingDefaultValues);
+            return GetOnlineMeetingDefaultValues(HttpService.GetNewCancellationToken());
+        }
+        public Task<OnlineMeetingDefaultValues> GetOnlineMeetingDefaultValues(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<OnlineMeetingDefaultValues>(Links.onlineMeetingDefaultValues, cancellationToken);
         }
 
-        public async Task<OnlineMeetingEligibleValues> GetOnlineMeetingEligibleValues()
+        public Task<OnlineMeetingEligibleValues> GetOnlineMeetingEligibleValues()
         {
-            return await HttpService.Get<OnlineMeetingEligibleValues>(Links.onlineMeetingEligibleValues);
+            return GetOnlineMeetingEligibleValues(HttpService.GetNewCancellationToken());
+        }
+        public Task<OnlineMeetingEligibleValues> GetOnlineMeetingEligibleValues(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<OnlineMeetingEligibleValues>(Links.onlineMeetingEligibleValues, cancellationToken);
         }
 
-        public async Task<OnlineMeetingInvitationCustomization> GetOnlineMeetingInvitationCustomization()
+        public Task<OnlineMeetingInvitationCustomization> GetOnlineMeetingInvitationCustomization()
         {
-            return await HttpService.Get<OnlineMeetingInvitationCustomization>(Links.onlineMeetingInvitationCustomization);
+            return GetOnlineMeetingInvitationCustomization(HttpService.GetNewCancellationToken());
+        }
+        public Task<OnlineMeetingInvitationCustomization> GetOnlineMeetingInvitationCustomization(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<OnlineMeetingInvitationCustomization>(Links.onlineMeetingInvitationCustomization, cancellationToken);
         }
 
-        public async Task<OnlineMeetingPolicies> GetOnlineMeetingPolicies()
+        public Task<OnlineMeetingPolicies> GetOnlineMeetingPolicies()
         {
-            return await HttpService.Get<OnlineMeetingPolicies>(Links.onlineMeetingPolicies);
+            return GetOnlineMeetingPolicies(HttpService.GetNewCancellationToken());
+        }
+        public Task<OnlineMeetingPolicies> GetOnlineMeetingPolicies(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<OnlineMeetingPolicies>(Links.onlineMeetingPolicies, cancellationToken);
         }
 
-        public async Task<PhoneDialInInformation> GetPhoneDialInInformation()
+        public Task<PhoneDialInInformation> GetPhoneDialInInformation()
         {
-            return await HttpService.Get<PhoneDialInInformation>(Links.phoneDialInInformation);
+            return GetPhoneDialInInformation(HttpService.GetNewCancellationToken());
+        }
+        public Task<PhoneDialInInformation> GetPhoneDialInInformation(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<PhoneDialInInformation>(Links.phoneDialInInformation, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/Participant.cs
+++ b/UCWASDK/UCWASDK/Models/Participant.cs
@@ -2,6 +2,7 @@
 using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -96,84 +97,163 @@ namespace Microsoft.Skype.UCWA.Models
             internal Reject reject { get; set; }
         }
 
-        public async Task Admit()
+        public Task Admit()
         {
-            await HttpService.Post(Links.admit, "");
+            return Admit(HttpService.GetNewCancellationToken());
         }
 
-        public async Task<Contact> GetContact()
+        public Task Admit(CancellationToken cancellationToken)
         {
-            return await HttpService.Get<Contact>(Links.contact);
+            return HttpService.Post(Links.admit, "", cancellationToken);
         }
 
-        public async Task<byte[]> GetContactPhoto()
+        public Task<Contact> GetContact()
         {
-            return await HttpService.GetBinary(Links.contactPhoto);
+            return GetContact(HttpService.GetNewCancellationToken());
         }
 
-        public async Task<ContactPresence> GetContactPresence()
+        public Task<Contact> GetContact(CancellationToken cancellationToken)
         {
-            return await HttpService.Get<ContactPresence>(Links.contactPresence);
+            return HttpService.Get<Contact>(Links.contact, cancellationToken);
         }
 
-        public async Task<Conversation> GetConversation()
+        public Task<byte[]> GetContactPhoto()
         {
-            return await HttpService.Get<Conversation>(Links.conversation);
+            return GetContactPhoto(HttpService.GetNewCancellationToken());
         }
 
-        public async Task Demote()
+        public Task<byte[]> GetContactPhoto(CancellationToken cancellationToken)
         {
-            await HttpService.Post(Links.demote, "");
-
-        }
-        public async Task Eject()
-        {
-            await HttpService.Post(Links.eject, "");
+            return HttpService.GetBinary(Links.contactPhoto, cancellationToken);
         }
 
-        public async Task<Me> GetMe()
+        public Task<ContactPresence> GetContactPresence()
         {
-            return await HttpService.Get<Me>(Links.me);
+            return GetContactPresence(HttpService.GetNewCancellationToken());
         }
 
-        public async Task<ParticipantApplicationSharing> GetParticipantApplicationSharing()
+        public Task<ContactPresence> GetContactPresence(CancellationToken cancellationToken)
         {
-            return await HttpService.Get<ParticipantApplicationSharing>(Links.participantApplicationSharing);
+            return HttpService.Get<ContactPresence>(Links.contactPresence, cancellationToken);
         }
 
-        public async Task<ParticipantAudio> GetParticipantAudio()
+        public Task<Conversation> GetConversation()
         {
-            return await HttpService.Get<ParticipantAudio>(Links.participantAudio);
+            return GetConversation(HttpService.GetNewCancellationToken());
         }
 
-        public async Task<ParticipantDataCollaboration> GetParticipantDataCollaboration()
+        public Task<Conversation> GetConversation(CancellationToken cancellationToken)
         {
-            return await HttpService.Get<ParticipantDataCollaboration>(Links.participantDataCollaboration);
+            return HttpService.Get<Conversation>(Links.conversation, cancellationToken);
         }
 
-        public async Task<ParticipantMessaging> GetParticipantMessaging()
+        public Task Demote()
         {
-            return await HttpService.Get<ParticipantMessaging>(Links.participantMessaging);
+            return Demote(HttpService.GetNewCancellationToken());
         }
 
-        public async Task<ParticipantPanoramicVideo> GetParticipantPanoramicVideo()
+        public Task Demote(CancellationToken cancellationToken)
         {
-            return await HttpService.Get<ParticipantPanoramicVideo>(Links.participantPanoramicVideo);
+            return  HttpService.Post(Links.demote, "", cancellationToken);
         }
 
-        public async Task<ParticipantVideo> GetParticipantVideo()
+        public Task Eject()
         {
-            return await HttpService.Get<ParticipantVideo>(Links.participantVideo);
+            return Eject(HttpService.GetNewCancellationToken());
         }
 
-        public async Task Promote()
+        public Task Eject(CancellationToken cancellationToken)
+        {
+            return HttpService.Post(Links.eject, "", cancellationToken);
+        }
+
+        public Task<Me> GetMe()
+        {
+            return GetMe(HttpService.GetNewCancellationToken());
+        }
+
+        public Task<Me> GetMe(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<Me>(Links.me, cancellationToken);
+        }
+
+        public Task<ParticipantApplicationSharing> GetParticipantApplicationSharing()
+        {
+            return GetParticipantApplicationSharing(HttpService.GetNewCancellationToken());
+        }
+
+        public Task<ParticipantApplicationSharing> GetParticipantApplicationSharing(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<ParticipantApplicationSharing>(Links.participantApplicationSharing, cancellationToken);
+        }
+
+        public Task<ParticipantAudio> GetParticipantAudio()
+        {
+            return GetParticipantAudio(HttpService.GetNewCancellationToken());
+        }
+
+        public Task<ParticipantAudio> GetParticipantAudio(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<ParticipantAudio>(Links.participantAudio, cancellationToken);
+        }
+
+        public Task<ParticipantDataCollaboration> GetParticipantDataCollaboration()
+        {
+            return GetParticipantDataCollaboration(HttpService.GetNewCancellationToken());
+        }
+
+        public Task<ParticipantDataCollaboration> GetParticipantDataCollaboration(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<ParticipantDataCollaboration>(Links.participantDataCollaboration, cancellationToken);
+        }
+
+        public Task<ParticipantMessaging> GetParticipantMessaging(){
+            return GetParticipantMessaging(HttpService.GetNewCancellationToken());
+        }
+
+        public Task<ParticipantMessaging> GetParticipantMessaging(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<ParticipantMessaging>(Links.participantMessaging, cancellationToken);
+        }
+
+        public Task<ParticipantPanoramicVideo> GetParticipantPanoramicVideo()
+        {
+            return GetParticipantPanoramicVideo(HttpService.GetNewCancellationToken());
+        }
+
+        public Task<ParticipantPanoramicVideo> GetParticipantPanoramicVideo(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<ParticipantPanoramicVideo>(Links.participantPanoramicVideo, cancellationToken);
+        }
+
+        public Task<ParticipantVideo> GetParticipantVideo()
+        {
+            return GetParticipantVideo(HttpService.GetNewCancellationToken());
+        }
+
+        public Task<ParticipantVideo> GetParticipantVideo(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<ParticipantVideo>(Links.participantVideo, cancellationToken);
+        }
+
+        public Task Promote()
+        {
+            return Promote(HttpService.GetNewCancellationToken());
+        }
+
+        public Task Promote(CancellationToken cancellationToken)
         { 
-            await HttpService.Post(Links.promote, "");
+            return HttpService.Post(Links.promote, "", cancellationToken);
         }
 
-        public async Task Reject()
+        public Task Reject()
         {
-            await HttpService.Post(Links.reject, "");
+            return Reject(HttpService.GetNewCancellationToken());
+        }
+
+        public Task Reject(CancellationToken cancellationToken)
+        {
+            return HttpService.Post(Links.reject, "", cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/ParticipantApplicationSharing.cs
+++ b/UCWASDK/UCWASDK/Models/ParticipantApplicationSharing.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -26,9 +27,13 @@ namespace Microsoft.Skype.UCWA.Models
             internal UCWAHref participant { get; set; }
         }
 
-        public async Task<Participant> GetParticipant()
+        public Task<Participant> GetParticipant()
         {
-            return await HttpService.Get<Participant>(Links.participant);
+            return GetParticipant(HttpService.GetNewCancellationToken());
+        }
+        public Task<Participant> GetParticipant(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<Participant>(Links.participant, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/ParticipantAudio.cs
+++ b/UCWASDK/UCWASDK/Models/ParticipantAudio.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Skype.UCWA.Enums;
 using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -41,19 +42,31 @@ namespace Microsoft.Skype.UCWA.Models
             internal UnmuteAudio unmuteAudio { get; set; }
         }
 
-        public async Task MuteAudio()
+        public Task MuteAudio()
         {
-            await HttpService.Post(Links.muteAudio, "");
+            return MuteAudio(HttpService.GetNewCancellationToken());
+        }
+        public Task MuteAudio(CancellationToken cancellationToken)
+        {
+             return HttpService.Post(Links.muteAudio, "", cancellationToken);
         }
 
-        public async Task<Participant> GetParticipant()
+        public Task<Participant> GetParticipant()
         {
-            return await HttpService.Get<Participant>(Links.participant);
+            return GetParticipant(HttpService.GetNewCancellationToken());
+        }
+        public Task<Participant> GetParticipant(CancellationToken cancellationToken)
+        {
+            return  HttpService.Get<Participant>(Links.participant, cancellationToken);
         }
 
-        public async Task UnmuteAudio()
+        public Task UnmuteAudio()
         {
-            await HttpService.Post(Links.unmuteAudio, "");
+            return UnmuteAudio(HttpService.GetNewCancellationToken());
+        }
+        public Task UnmuteAudio(CancellationToken cancellationToken)
+        {
+             return HttpService.Post(Links.unmuteAudio, "", cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/ParticipantDataCollaboration.cs
+++ b/UCWASDK/UCWASDK/Models/ParticipantDataCollaboration.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -26,9 +27,13 @@ namespace Microsoft.Skype.UCWA.Models
             internal UCWAHref participant { get; set; }
         }
 
-        public async Task<Participant> GetParticipant()
+        public Task<Participant> GetParticipant()
         {
-            return await HttpService.Get<Participant>(Links.participant);
+            return GetParticipant(HttpService.GetNewCancellationToken());
+        }
+        public Task<Participant> GetParticipant(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<Participant>(Links.participant, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/ParticipantInvitation.cs
+++ b/UCWASDK/UCWASDK/Models/ParticipantInvitation.cs
@@ -2,6 +2,7 @@
 using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -62,13 +63,13 @@ namespace Microsoft.Skype.UCWA.Models
 
             [JsonProperty("customContent")]
             internal UCWAHref customContent { get; set; }
-  
+
             [JsonProperty("message")]
-            internal UCWAHref message { get; set; }  
-         
+            internal UCWAHref message { get; set; }
+
             [JsonProperty("cancel")]
             internal Cancel cancel { get; set; }
-  
+
             [JsonProperty("conversation")]
             internal UCWAHref conversation { get; set; }
 
@@ -77,7 +78,7 @@ namespace Microsoft.Skype.UCWA.Models
 
             [JsonProperty("participant")]
             internal UCWAHref participant { get; set; }
-  
+
             [JsonProperty("to")]
             internal UCWAHref to { get; set; }
         }
@@ -91,29 +92,49 @@ namespace Microsoft.Skype.UCWA.Models
             internal From from { get; set; }
         }
 
-        public async Task Cancel()
+        public Task Cancel()
         {
-            await HttpService.Post(Links.cancel, "");
+            return Cancel(HttpService.GetNewCancellationToken());
+        }
+        public Task Cancel(CancellationToken cancellationToken)
+        {
+            return HttpService.Post(Links.cancel, "", cancellationToken);
         }
 
-        public async Task<Conversation> GetConversation()
+        public Task<Conversation> GetConversation()
         {
-            return await HttpService.Get<Conversation>(Links.conversation);
+            return GetConversation(HttpService.GetNewCancellationToken());
+        }
+        public Task<Conversation> GetConversation(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<Conversation>(Links.conversation, cancellationToken);
         }
 
-        public async Task<From> GetFrom()
+        public Task<From> GetFrom()
         {
-            return await HttpService.Get<From>(Links.from);
+            return GetFrom(HttpService.GetNewCancellationToken());
+        }
+        public Task<From> GetFrom(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<From>(Links.from, cancellationToken);
         }
 
-        public async Task<Participant> GetParticipant()
+        public Task<Participant> GetParticipant()
         {
-            return await HttpService.Get<Participant>(Links.participant);
+            return GetParticipant(HttpService.GetNewCancellationToken());
+        }
+        public Task<Participant> GetParticipant(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<Participant>(Links.participant, cancellationToken);
         }
 
-        public async Task<To> GetTo()
+        public Task<To> GetTo()
         {
-            return await HttpService.Get<To>(Links.to);
+            return GetTo(HttpService.GetNewCancellationToken());
+        }
+        public Task<To> GetTo(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<To>(Links.to, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/ParticipantMessaging.cs
+++ b/UCWASDK/UCWASDK/Models/ParticipantMessaging.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -26,9 +27,13 @@ namespace Microsoft.Skype.UCWA.Models
             internal UCWAHref participant { get; set; }
         }
 
-        public async Task<Participant> GetParticipant()
+        public Task<Participant> GetParticipant()
         {
-            return await HttpService.Get<Participant>(Links.participant);
+            return GetParticipant(HttpService.GetNewCancellationToken());
+        }
+        public Task<Participant> GetParticipant(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<Participant>(Links.participant, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/ParticipantPanoramicVideo.cs
+++ b/UCWASDK/UCWASDK/Models/ParticipantPanoramicVideo.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Skype.UCWA.Enums;
 using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -36,9 +37,13 @@ namespace Microsoft.Skype.UCWA.Models
             internal UCWAHref participant { get; set; }   
         }
 
-        public async Task<Participant> GetParticipant()
+        public Task<Participant> GetParticipant()
         {
-            return await HttpService.Get<Participant>(Links.participant);
+            return GetParticipant(HttpService.GetNewCancellationToken());
+        }
+        public Task<Participant> GetParticipant(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<Participant>(Links.participant, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/ParticipantVideo.cs
+++ b/UCWASDK/UCWASDK/Models/ParticipantVideo.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Skype.UCWA.Enums;
 using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -33,27 +34,39 @@ namespace Microsoft.Skype.UCWA.Models
 
             [JsonProperty("muteVideo")]
             internal MuteVideo muteVideo { get; set; }
-   
+
             [JsonProperty("participant")]
             internal UCWAHref participant { get; set; }
-   
+
             [JsonProperty("unmuteVideo")]
             internal UnmuteVideo unmuteVideo { get; set; }
         }
 
-        public async Task MuteVideo()
+        public Task MuteVideo()
         {
-            await HttpService.Post(Links.muteVideo, "");
+            return MuteVideo(HttpService.GetNewCancellationToken());
+        }
+        public Task MuteVideo(CancellationToken cancellationToken)
+        {
+            return HttpService.Post(Links.muteVideo, "", cancellationToken);
         }
 
-        public async Task<Participant> GetParticipant()
+        public Task<Participant> GetParticipant()
         {
-            return await HttpService.Get<Participant>(Links.participant);
+            return GetParticipant(HttpService.GetNewCancellationToken());
+        }
+        public Task<Participant> GetParticipant(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<Participant>(Links.participant, cancellationToken);
         }
 
-        public async Task UnmuteVideo()
+        public Task UnmuteVideo()
         {
-            await HttpService.Post(Links.unmuteVideo, "");
+            return UnmuteVideo(HttpService.GetNewCancellationToken());
+        }
+        public Task UnmuteVideo(CancellationToken cancellationToken)
+        {
+            return HttpService.Post(Links.unmuteVideo, "", cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/People.cs
+++ b/UCWASDK/UCWASDK/Models/People.cs
@@ -25,65 +25,100 @@ namespace Microsoft.Skype.UCWA.Models
 
             [JsonProperty("myContactsAndGroupsSubscription")]
             internal UCWAHref myContactsAndGroupsSubscription { get; set; }
-        
+
             [JsonProperty("myContacts")]
             internal UCWAHref myContacts { get; set; }
-        
+
             [JsonProperty("myGroupMemberships")]
             internal UCWAHref myGroupMemberships { get; set; }
-        
+
             [JsonProperty("myGroups")]
             internal UCWAHref myGroups { get; set; }
 
             [JsonProperty("myPrivacyRelationships")]
             internal UCWAHref myPrivacyRelationships { get; set; }
-        
+
             [JsonProperty("presenceSubscriptionMemberships")]
             internal UCWAHref presenceSubscriptionMemberships { get; set; }
-        
+
             [JsonProperty("presenceSubscriptions")]
             internal UCWAHref presenceSubscriptions { get; set; }
-        
+
             [JsonProperty("search")]
             internal UCWAHref search { get; set; }
-        
+
             [JsonProperty("subscribedContacts")]
             internal UCWAHref subscribedContacts { get; set; }
         }
 
-        public async Task<MyContactsAndGroupsSubscription> GetMyContactsAndGroupsSubscription()
+        public Task<MyContactsAndGroupsSubscription> GetMyContactsAndGroupsSubscription()
         {
-            return await HttpService.Get<MyContactsAndGroupsSubscription>(Links.myContactsAndGroupsSubscription);
+            return GetMyContactsAndGroupsSubscription(HttpService.GetNewCancellationToken());
         }
 
-        public async Task<MyContacts> GetMyContacts()
+        public Task<MyContactsAndGroupsSubscription> GetMyContactsAndGroupsSubscription(CancellationToken cancellationToken)
         {
-            return await HttpService.Get<MyContacts>(Links.myContacts);
+            return HttpService.Get<MyContactsAndGroupsSubscription>(Links.myContactsAndGroupsSubscription, cancellationToken);
         }
 
-        public async Task<MyGroupMemberships2> GetMyGroupMemberships()
+        public Task<MyContacts> GetMyContacts()
         {
-            return await HttpService.Get<MyGroupMemberships2>(Links.myGroupMemberships);
+            return GetMyContacts(HttpService.GetNewCancellationToken());
         }
 
-        public async Task<MyGroups2> GetMyGroups()
+        public Task<MyContacts> GetMyContacts(CancellationToken cancellationToken)
         {
-            return await HttpService.Get<MyGroups2>(Links.myGroups);
+            return HttpService.Get<MyContacts>(Links.myContacts, cancellationToken);
         }
 
-        public async Task<MyPrivacyRelationships> GetMyPrivacyRelationships()
+        public Task<MyGroupMemberships2> GetMyGroupMemberships()
         {
-            return await HttpService.Get<MyPrivacyRelationships>(Links.myPrivacyRelationships);
+            return GetMyGroupMemberships(HttpService.GetNewCancellationToken());
         }
 
-        public async Task<PresenceSubscriptionMemberships> GetPresenceSubscriptionMemberships()
+        public Task<MyGroupMemberships2> GetMyGroupMemberships(CancellationToken cancellationToken)
         {
-            return await HttpService.Get<PresenceSubscriptionMemberships>(Links.presenceSubscriptionMemberships);
+            return HttpService.Get<MyGroupMemberships2>(Links.myGroupMemberships, cancellationToken);
         }
 
-        public async Task<PresenceSubscriptions> GetPresenceSubscriptions()
+        public Task<MyGroups2> GetMyGroups()
         {
-            return await HttpService.Get<PresenceSubscriptions>(Links.presenceSubscriptions);
+            return GetMyGroups(HttpService.GetNewCancellationToken());
+        }
+
+        public Task<MyGroups2> GetMyGroups(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<MyGroups2>(Links.myGroups, cancellationToken);
+        }
+
+        public Task<MyPrivacyRelationships> GetMyPrivacyRelationships()
+        {
+            return GetMyPrivacyRelationships(HttpService.GetNewCancellationToken());
+        }
+
+        public Task<MyPrivacyRelationships> GetMyPrivacyRelationships(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<MyPrivacyRelationships>(Links.myPrivacyRelationships, cancellationToken);
+        }
+
+        public Task<PresenceSubscriptionMemberships> GetPresenceSubscriptionMemberships()
+        {
+            return GetPresenceSubscriptionMemberships(HttpService.GetNewCancellationToken());
+        }
+
+        public Task<PresenceSubscriptionMemberships> GetPresenceSubscriptionMemberships(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<PresenceSubscriptionMemberships>(Links.presenceSubscriptionMemberships, cancellationToken);
+        }
+
+        public Task<PresenceSubscriptions> GetPresenceSubscriptions()
+        {
+            return GetPresenceSubscriptions(HttpService.GetNewCancellationToken());
+        }
+
+        public Task<PresenceSubscriptions> GetPresenceSubscriptions(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<PresenceSubscriptions>(Links.presenceSubscriptions, cancellationToken);
         }
 
         public Task<Search2> Search(string query)
@@ -100,9 +135,14 @@ namespace Microsoft.Skype.UCWA.Models
             return await HttpService.Get<Search2>(uri, cancellationToken);
         }
 
-        public async Task<SubscribedContacts> GetSubscribedContacts()
+        public Task<SubscribedContacts> GetSubscribedContacts()
         {
-            return await HttpService.Get<SubscribedContacts>(Links.subscribedContacts);
-        }        
+            return GetSubscribedContacts(Links.subscribedContacts, HttpService.GetNewCancellationToken());
+        }
+
+        public Task<SubscribedContacts> GetSubscribedContacts(UCWAHref subscribedContacts, CancellationToken cancellationToken)
+        {
+            return HttpService.Get<SubscribedContacts>(subscribedContacts, cancellationToken);
+        }
     }
 }

--- a/UCWASDK/UCWASDK/Models/People.cs
+++ b/UCWASDK/UCWASDK/Models/People.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -85,13 +86,18 @@ namespace Microsoft.Skype.UCWA.Models
             return await HttpService.Get<PresenceSubscriptions>(Links.presenceSubscriptions);
         }
 
-        public async Task<Search2> Search(string query)
+        public Task<Search2> Search(string query)
+        {
+            return Search(query, HttpService.GetNewCancellationToken());
+        }
+
+        public async Task<Search2> Search(string query, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(query))
                 return null;
 
             var uri = Links.search.Href + "?query=" + query;
-            return await HttpService.Get<Search2>(uri);
+            return await HttpService.Get<Search2>(uri, cancellationToken);
         }
 
         public async Task<SubscribedContacts> GetSubscribedContacts()

--- a/UCWASDK/UCWASDK/Models/Phone.cs
+++ b/UCWASDK/UCWASDK/Models/Phone.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -39,17 +40,27 @@ namespace Microsoft.Skype.UCWA.Models
 
         public async Task ChangeNumber(string number)
         {
+            await ChangeNumber(number, HttpService.GetNewCancellationToken());
+        }
+
+        public async Task ChangeNumber(string number, CancellationToken cancellationToken)
+        {
             if (string.IsNullOrEmpty(number))
                 return;
             
-            await HttpService.Post($"{Links.changeNumber.Href}?number={number}", null);
+            await HttpService.Post($"{Links.changeNumber.Href}?number={number}", null, cancellationToken);
         }
 
         public async Task ChangeVisibility(bool includeInContactCard)
         {
+            await ChangeVisibility(includeInContactCard, HttpService.GetNewCancellationToken());
+        }
+
+        public async Task ChangeVisibility(bool includeInContactCard, CancellationToken cancellationToken)
+        {
             var uri = includeInContactCard ? Links.changeVisibility.Href + "?includeInContactCard" : Links.changeVisibility.Href;
             
-            await HttpService.Post(uri, "");
+            await HttpService.Post(uri, "", cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/PhoneAudio.cs
+++ b/UCWASDK/UCWASDK/Models/PhoneAudio.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -43,6 +44,11 @@ namespace Microsoft.Skype.UCWA.Models
 
         public async Task AddPhoneAudio(string sipName, string phoneNumber)
         {
+            await AddPhoneAudio(sipName, phoneNumber, HttpService.GetNewCancellationToken());
+        }
+
+        public async Task AddPhoneAudio(string sipName, string phoneNumber, CancellationToken cancellationToken)
+        {
             if (string.IsNullOrEmpty(sipName) && string.IsNullOrEmpty(phoneNumber))
                 return;
             
@@ -53,27 +59,47 @@ namespace Microsoft.Skype.UCWA.Models
                 OperationId = Guid.NewGuid().ToString()
             };
 
-            await HttpService.Post(Links.addPhoneAudio, invitaion);
+            await HttpService.Post(Links.addPhoneAudio, invitaion, cancellationToken);
         }
 
-        public async Task<Conversation> GetConversation()
+        public Task<Conversation> GetConversation()
         {
-            return await HttpService.Get<Conversation>(Links.conversation);
+             return GetConversation(HttpService.GetNewCancellationToken());
+        }
+
+        public Task<Conversation> GetConversation(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<Conversation>(Links.conversation, cancellationToken);
         }
 
         public async Task HoldPhoneAudio()
         {
-            await HttpService.Post(Links.holdPhoneAudio, "");
+            await HoldPhoneAudio(HttpService.GetNewCancellationToken());
+        }
+
+        public async Task HoldPhoneAudio(CancellationToken cancellationToken)
+        {
+            await HttpService.Post(Links.holdPhoneAudio, "", cancellationToken);
         }
 
         public async Task ResumePhoneAudio()
         {
-            await HttpService.Post(Links.resumePhoneAudio, "");
+            await ResumePhoneAudio(HttpService.GetNewCancellationToken());
+        }
+
+        public async Task ResumePhoneAudio(CancellationToken cancellationToken)
+        {
+            await HttpService.Post(Links.resumePhoneAudio, "", cancellationToken);
         }
 
         public async Task StopPhoneAudio()
         {
-            await HttpService.Post(Links.stopPhoneAudio, "");
+            await StopPhoneAudio(HttpService.GetNewCancellationToken());
+        }
+
+        public async Task StopPhoneAudio(CancellationToken cancellationToken)
+        {
+            await HttpService.Post(Links.stopPhoneAudio, "", cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/PhoneAudioInvitation.cs
+++ b/UCWASDK/UCWASDK/Models/PhoneAudioInvitation.cs
@@ -2,6 +2,7 @@
 using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -119,71 +120,136 @@ namespace Microsoft.Skype.UCWA.Models
 
         public async Task Accept()
         {
-            await HttpService.Post(Links.accept, "");
+            await Accept(HttpService.GetNewCancellationToken());
         }
 
-        public async Task<AcceptedByContact> GetAcceptedByContact()
+        public async Task Accept(CancellationToken cancellationToken)
         {
-            return await HttpService.Get<AcceptedByContact>(Links.acceptedByContact);
+            await HttpService.Post(Links.accept, "", cancellationToken);
+        }
+
+        public Task<AcceptedByContact> GetAcceptedByContact()
+        {
+            return GetAcceptedByContact(HttpService.GetNewCancellationToken());
+        }
+
+        public Task<AcceptedByContact> GetAcceptedByContact(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<AcceptedByContact>(Links.acceptedByContact, cancellationToken);
         }
 
         public async Task Cancel()
         {
-            await HttpService.Post(Links.cancel, "");
+            await Cancel(HttpService.GetNewCancellationToken());
         }
 
-        public async Task<Conversation> GetConversation()
+        public async Task Cancel(CancellationToken cancellationToken)
         {
-            return await HttpService.Get<Conversation>(Links.conversation);
+            await HttpService.Post(Links.cancel, "", cancellationToken);
+        }
+
+        public Task<Conversation> GetConversation()
+        {
+            return GetConversation(HttpService.GetNewCancellationToken());
+        }
+
+        public Task<Conversation> GetConversation(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<Conversation>(Links.conversation, cancellationToken);
         }
 
         public async Task Decline(CallDeclineReason reason)
+        {
+            await Decline(reason, HttpService.GetNewCancellationToken());
+        }
+
+        public async Task Decline(CallDeclineReason reason, CancellationToken cancellationToken)
         {
             CallDecline callDecline = new CallDecline()
             {
                 Reason = reason
             };
-            await HttpService.Post(Links.decline, callDecline);
+            await HttpService.Post(Links.decline, callDecline, cancellationToken);
         }
 
-        public async Task<DerivedConversation> GetDerivedConversation()
+        public Task<DerivedConversation> GetDerivedConversation()
         {
-            return await HttpService.Get<DerivedConversation>(Links.derivedConversation);
+            return GetDerivedConversation(HttpService.GetNewCancellationToken());
         }
 
-        public async Task<DerivedPhoneAudio> GetDerivedPhoneAudio()
+        public Task<DerivedConversation> GetDerivedConversation(CancellationToken cancellationToken)
         {
-            return await HttpService.Get<DerivedPhoneAudio>(Links.derivedPhoneAudio);
+            return HttpService.Get<DerivedConversation>(Links.derivedConversation, cancellationToken);
         }
 
-        public async Task<ForwardedBy> GetForwardedBy()
+        public Task<DerivedPhoneAudio> GetDerivedPhoneAudio()
         {
-            return await HttpService.Get<ForwardedBy>(Links.forwardedBy);
+            return GetDerivedPhoneAudio(HttpService.GetNewCancellationToken());
         }
 
-        public async Task<From> GetFrom()
+        public Task<DerivedPhoneAudio> GetDerivedPhoneAudio(CancellationToken cancellationToken)
         {
-            return await HttpService.Get<From>(Links.from);
+            return HttpService.Get<DerivedPhoneAudio>(Links.derivedPhoneAudio, cancellationToken);
         }
 
-        public async Task<OnBehalfOf> GetOnBehalfOf()
+        public Task<ForwardedBy> GetForwardedBy()
         {
-            return await HttpService.Get<OnBehalfOf>(Links.onBehalfOf);
+            return GetForwardedBy(HttpService.GetNewCancellationToken());
         }
 
-        public async Task<PhoneAudio> GetPhoneAudio()
+        public Task<ForwardedBy> GetForwardedBy(CancellationToken cancellationToken)
         {
-            return await HttpService.Get<PhoneAudio>(Links.phoneAudio);
+            return  HttpService.Get<ForwardedBy>(Links.forwardedBy, cancellationToken);
         }
 
-        public async Task<To> GetTo()
+        public Task<From> GetFrom()
         {
-            return await HttpService.Get<To>(Links.to);
+            return GetFrom(HttpService.GetNewCancellationToken());
         }
 
-        public async Task<TransferredBy> GetTransferredBy()
+        public Task<From> GetFrom(CancellationToken cancellationToken)
         {
-            return await HttpService.Get<TransferredBy>(Links.transferredBy);
+            return HttpService.Get<From>(Links.from, cancellationToken);
+        }
+
+        public Task<OnBehalfOf> GetOnBehalfOf()
+        {
+            return GetOnBehalfOf(HttpService.GetNewCancellationToken());
+        }
+
+        public Task<OnBehalfOf> GetOnBehalfOf(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<OnBehalfOf>(Links.onBehalfOf, cancellationToken);
+        }
+
+        public Task<PhoneAudio> GetPhoneAudio()
+        {
+            return GetPhoneAudio(HttpService.GetNewCancellationToken());
+        }
+
+        public Task<PhoneAudio> GetPhoneAudio(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<PhoneAudio>(Links.phoneAudio, cancellationToken);
+        }
+
+        public Task<To> GetTo()
+        {
+            return GetTo(HttpService.GetNewCancellationToken());
+        }
+
+        public Task<To> GetTo(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<To>(Links.to, cancellationToken);
+        }
+
+        public Task<TransferredBy> GetTransferredBy()
+        {
+            return GetTransferredBy(HttpService.GetNewCancellationToken());
+        }
+
+        public Task<TransferredBy> GetTransferredBy(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<TransferredBy>(Links.transferredBy, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/Presence.cs
+++ b/UCWASDK/UCWASDK/Models/Presence.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Skype.UCWA.Enums;
 using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -19,7 +20,12 @@ namespace Microsoft.Skype.UCWA.Models
 
         public async Task Update()
         {
-            await HttpService.Post(Self, this);
+            await Update(HttpService.GetNewCancellationToken());
+        }
+
+        public async Task Update(CancellationToken cancellationToken)
+        {
+            await HttpService.Post(Self, this, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/PresenceSubscription.cs
+++ b/UCWASDK/UCWASDK/Models/PresenceSubscription.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -31,8 +32,12 @@ namespace Microsoft.Skype.UCWA.Models
             [JsonProperty("memberships")]
             internal UCWAHref memberships { get; set; }
         }
+        public Task<PresenceSubscriptionMemberships> AddToPresenceSubscription(params string[] sips)
+        {
+            return AddToPresenceSubscription(HttpService.GetNewCancellationToken(), sips);
+        }
 
-        public async Task<PresenceSubscriptionMemberships> AddToPresenceSubscription(params string[] sips)
+        public async Task<PresenceSubscriptionMemberships> AddToPresenceSubscription(CancellationToken cancellationToken, params string[] sips)
         {
             if (sips == null || sips.Length == 0)
                 return null;
@@ -42,17 +47,27 @@ namespace Microsoft.Skype.UCWA.Models
             foreach (var sip in sips) { contactUris.Add(sip); }
             body["ContactUris"] = contactUris;
 
-            return await HttpService.Post<PresenceSubscriptionMemberships>(Links.addToPresenceSubscription, body);
+            return await HttpService.Post<PresenceSubscriptionMemberships>(Links.addToPresenceSubscription, body, cancellationToken);
         }
 
-        public async Task<Memberships> GetMemberships()
+        public Task<Memberships> GetMemberships()
         {
-            return await HttpService.Get<Memberships>(Links.memberships);
+            return GetMemberships(HttpService.GetNewCancellationToken());
+        }
+
+        public Task<Memberships> GetMemberships(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<Memberships>(Links.memberships, cancellationToken);
         }
 
         public async Task Delete()
         {
-            await HttpService.Delete(Self);
+            await Delete(HttpService.GetNewCancellationToken());
+        }
+
+        public async Task Delete(CancellationToken cancellationToken)
+        {
+            await HttpService.Delete(Self, cancellationToken);
         }
     }    
 }

--- a/UCWASDK/UCWASDK/Models/PresenceSubscriptionMembership.cs
+++ b/UCWASDK/UCWASDK/Models/PresenceSubscriptionMembership.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -28,19 +29,34 @@ namespace Microsoft.Skype.UCWA.Models
             internal UCWAHref presenceSubscription { get; set; }
         }
 
-        public async Task<Contact> GetContact()
+        public Task<Contact> GetContact()
         {
-            return await HttpService.Get<Contact>(Links.contact);
+            return GetContact(HttpService.GetNewCancellationToken());
         }
 
-        public async Task<PresenceSubscription> GetPresenceSubscription()
+        public Task<Contact> GetContact(CancellationToken cancellationToken)
         {
-            return await HttpService.Get<PresenceSubscription>(Links.presenceSubscription);
+            return HttpService.Get<Contact>(Links.contact, cancellationToken);
         }
 
-        public async Task RemoveContactFromPresenceSubscription()
+        public Task<PresenceSubscription> GetPresenceSubscription()
         {
-            await HttpService.Delete(Self);
+            return GetPresenceSubscription(HttpService.GetNewCancellationToken());
+        }
+
+        public async Task<PresenceSubscription> GetPresenceSubscription(CancellationToken cancellationToken)
+        {
+            return await HttpService.Get<PresenceSubscription>(Links.presenceSubscription, cancellationToken);
+        }
+
+        public Task RemoveContactFromPresenceSubscription()
+        {
+            return RemoveContactFromPresenceSubscription(HttpService.GetNewCancellationToken());
+        }
+
+        public async Task RemoveContactFromPresenceSubscription(CancellationToken cancellationToken)
+        {
+            await HttpService.Delete(Self, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/PresenceSubscriptions.cs
+++ b/UCWASDK/UCWASDK/Models/PresenceSubscriptions.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -26,6 +27,11 @@ namespace Microsoft.Skype.UCWA.Models
 
         public async Task<PresenceSubscription> SubscribeToContactsPresence(string[] uris, int duration = 30)
         {
+            return await SubscribeToContactsPresence(HttpService.GetNewCancellationToken(), uris, duration);
+        }
+
+        public async Task<PresenceSubscription> SubscribeToContactsPresence(CancellationToken cancellationToken, string[] uris, int duration = 30)
+        {
             if (uris == null || uris.Count() == 0)
                 return null;
 
@@ -35,13 +41,18 @@ namespace Microsoft.Skype.UCWA.Models
             JObject body = new JObject();
             body["duration"] = 30;
             body["uris"] = new JArray(uris);
-            return await HttpService.Post<PresenceSubscription>(Self, body);
+            return await HttpService.Post<PresenceSubscription>(Self, body, cancellationToken);
         }
 
         public async Task<PresenceSubscription> Renew()
         {
+            return await Renew(HttpService.GetNewCancellationToken());
+        }
+
+        public async Task<PresenceSubscription> Renew(CancellationToken cancellationToken)
+        {
             var uri = Self + "?duration=30";
-            return await HttpService.Post<PresenceSubscription>(uri, null);
+            return await HttpService.Post<PresenceSubscription>(uri, null, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/Redirect.cs
+++ b/UCWASDK/UCWASDK/Models/Redirect.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -22,16 +23,26 @@ namespace Microsoft.Skype.UCWA.Models
 
             [JsonProperty("xframe")]
             internal Xframe xframe { get; set; }
-        }        
-        
-        public async Task<User> GetUser()
-        {
-            return await HttpService.Get<User>(Links.user);
         }
 
-        public async Task<Xframe> GetXframe()
+        public Task<User> GetUser()
         {
-            return await HttpService.Get<Xframe>(Links.xframe);
+            return GetUser(HttpService.GetNewCancellationToken());
+        }
+
+        public  Task<User> GetUser(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<User>(Links.user, cancellationToken);
+        }
+
+        public Task<Xframe> GetXframe()
+        {
+            return GetXframe(HttpService.GetNewCancellationToken());
+        }
+
+        public Task<Xframe> GetXframe(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<Xframe>(Links.xframe, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/Root.cs
+++ b/UCWASDK/UCWASDK/Models/Root.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -31,19 +32,34 @@ namespace Microsoft.Skype.UCWA.Models
             internal UCWAHref xframe { get; set; }
         }
 
-        public async Task<Redirect> GetRedirect()
+        public Task<Redirect> GetRedirect()
         {
-            return Links.redirect == null ? null : await HttpService.Get<Redirect>(Links.redirect, anonymous: true);
+            return GetRedirect(HttpService.GetNewCancellationToken());
         }
 
-        public async Task<User> GetUser()
+        public async Task<Redirect> GetRedirect(CancellationToken cancellationToken)
         {
-            return await HttpService.Get<User>(Links.user);
+            return Links.redirect == null ? null : await HttpService.Get<Redirect>(Links.redirect, anonymous: true, cancellationToken:cancellationToken);
         }
 
-        public async Task<Xframe> GetXframe()
+        public Task<User> GetUser()
         {
-            return await HttpService.Get<Xframe>(Links.xframe);
+            return GetUser(HttpService.GetNewCancellationToken());
+        }
+
+        public Task<User> GetUser(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<User>(Links.user, cancellationToken);
+        }
+
+        public Task<Xframe> GetXframe()
+        {
+            return GetXframe(HttpService.GetNewCancellationToken());
+        }
+
+        public Task<Xframe> GetXframe(CancellationToken cancellationToken)
+        {
+            return  HttpService.Get<Xframe>(Links.xframe, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/SimultaneousRingSettings.cs
+++ b/UCWASDK/UCWASDK/Models/SimultaneousRingSettings.cs
@@ -2,6 +2,7 @@
 using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -41,25 +42,45 @@ namespace Microsoft.Skype.UCWA.Models
             [JsonProperty("simultaneousRingToTeam")]
             internal SimultaneousRingToTeam simultaneousRingToTeam { get; set; }
         }
-                
-        public async Task<Contact> GetContact()
+
+        public Task<Contact> GetContact()
         {
-            return await HttpService.Get<Contact>(Links.contact);
+            return GetContact(HttpService.GetNewCancellationToken());
         }
 
-        public async Task SimultaneousRingToContact()
+        public Task<Contact> GetContact(CancellationToken cancellationToken)
         {
-            await HttpService.Post(Links.simultaneousRingToContact, this);
+            return HttpService.Get<Contact>(Links.contact, cancellationToken);
         }
 
-        public async Task SimultaneousRingToDelegates()
+        public Task SimultaneousRingToContact()
         {
-            await HttpService.Post(Links.simultaneousRingToDelegates, this);
+            return SimultaneousRingToContact(HttpService.GetNewCancellationToken());
         }
 
-        public async Task SimultaneousRingToTeam(int? ringDelay)
+        public Task SimultaneousRingToContact(CancellationToken cancellationToken)
         {
-            await HttpService.Post(Links.simultaneousRingToTeam, this);
+            return HttpService.Post(Links.simultaneousRingToContact, this, cancellationToken);
+        }
+
+        public Task SimultaneousRingToDelegates()
+        {
+            return SimultaneousRingToDelegates(HttpService.GetNewCancellationToken());
+        }
+
+        public Task SimultaneousRingToDelegates(CancellationToken cancellationToken)
+        {
+            return HttpService.Post(Links.simultaneousRingToDelegates, this, cancellationToken);
+        }
+
+        public Task SimultaneousRingToTeam(int? ringDelay)
+        {
+            return SimultaneousRingToTeam(ringDelay, HttpService.GetNewCancellationToken());
+        }
+
+        public Task SimultaneousRingToTeam(int? ringDelay, CancellationToken cancellationToken)
+        {
+            return HttpService.Post(Links.simultaneousRingToTeam, this, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/SubscribedContacts.cs
+++ b/UCWASDK/UCWASDK/Models/SubscribedContacts.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -29,14 +30,24 @@ namespace Microsoft.Skype.UCWA.Models
             internal UCWAHref[] contact { get; set; }
         }
 
-        public async Task<Batch> GetBatch()
+        public Task<Batch> GetBatch()
         {
-            return await HttpService.Get<Batch>(Links.batch);
+            return GetBatch(HttpService.GetNewCancellationToken());
         }
 
-        public async Task<List<Contact>> GetContacts()
+        public Task<Batch> GetBatch(CancellationToken cancellationToken)
         {
-            return await HttpService.GetList<Contact>(Links.contact);
+            return HttpService.Get<Batch>(Links.batch, cancellationToken);
+        }
+
+        public Task<List<Contact>> GetContacts()
+        {
+            return GetContacts(HttpService.GetNewCancellationToken());
+        }
+
+        public async Task<List<Contact>> GetContacts(CancellationToken cancellationToken)
+        {
+            return await HttpService.GetList<Contact>(Links.contact, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/UnansweredCallSettings.cs
+++ b/UCWASDK/UCWASDK/Models/UnansweredCallSettings.cs
@@ -2,6 +2,7 @@
 using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -42,24 +43,44 @@ namespace Microsoft.Skype.UCWA.Models
             internal UnansweredCallToVoicemail unansweredCallToVoicemail { get; set; }
         }
 
-        public async Task<Contact> GetContact()
+        public Task<Contact> GetContact()
         {
-            return await HttpService.Get<Contact>(Links.contact);
+            return GetContact(HttpService.GetNewCancellationToken());
         }
 
-        public async Task ResetUnansweredCallSettings()
+        public Task<Contact> GetContact(CancellationToken cancellationToken)
         {
-            await HttpService.Post(Links.resetUnansweredCallSettings, "");
+            return HttpService.Get<Contact>(Links.contact, cancellationToken);
         }
 
-        public async Task UnansweredCallToContact()
+        public Task ResetUnansweredCallSettings()
+        {
+            return ResetUnansweredCallSettings(HttpService.GetNewCancellationToken());
+        }
+
+        public async Task ResetUnansweredCallSettings(CancellationToken cancellationToken)
+        {
+            await HttpService.Post(Links.resetUnansweredCallSettings, "", cancellationToken);
+        }
+
+        public Task UnansweredCallToContact()
+        {
+            return UnansweredCallToContact(HttpService.GetNewCancellationToken());
+        }
+
+        public Task UnansweredCallToContact(CancellationToken cancellationToken)
         { 
-            await HttpService.Post(Links.unansweredCallToContact, this);
+            return HttpService.Post(Links.unansweredCallToContact, this, cancellationToken);
         }
 
-        public async Task UnansweredCallToVoicemail()
+        public Task UnansweredCallToVoicemail()
         {
-            await HttpService.Post(Links.unansweredCallToVoicemail, this);
+            return UnansweredCallToVoicemail(HttpService.GetNewCancellationToken());
+        }
+
+        public Task UnansweredCallToVoicemail(CancellationToken cancellationToken)
+        {
+            return HttpService.Post(Links.unansweredCallToVoicemail, this, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Models/User.cs
+++ b/UCWASDK/UCWASDK/Models/User.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Skype.UCWA.Services;
 using Newtonsoft.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Models
@@ -31,7 +32,12 @@ namespace Microsoft.Skype.UCWA.Models
             internal Xframe xframe { get; set; }
         }
 
-        public async Task<Application> CreateApplication(string userAgent, string EndpointId, string Culture)
+        public Task<Application> CreateApplication(string userAgent, string EndpointId, string Culture)
+        {
+            return CreateApplication(userAgent, EndpointId, Culture, HttpService.GetNewCancellationToken());
+        }
+
+        public Task<Application> CreateApplication(string userAgent, string EndpointId, string Culture, CancellationToken cancellationToken)
         {
             Application application = new Models.Application()
             {
@@ -39,17 +45,27 @@ namespace Microsoft.Skype.UCWA.Models
                 EndpointId = EndpointId,
                 Culture = Culture
             };
-            return await HttpService.Post<Application>(Links.applications, application);
+            return HttpService.Post<Application>(Links.applications, application, cancellationToken);
         }
 
-        public async Task<Redirect> GetRedirect()
+        public Task<Redirect> GetRedirect()
         {
-            return await HttpService.Get<Redirect>(Links.redirect);
+            return GetRedirect(HttpService.GetNewCancellationToken());
         }
 
-        public async Task<Xframe> GetXframe()
+        public Task<Redirect> GetRedirect(CancellationToken cancellationToken)
         {
-            return await HttpService.Get<Xframe>(Links.xframe);
+            return HttpService.Get<Redirect>(Links.redirect, cancellationToken);
+        }
+
+        public Task<Xframe> GetXframe()
+        {
+            return GetXframe(HttpService.GetNewCancellationToken());
+        }
+
+        public Task<Xframe> GetXframe(CancellationToken cancellationToken)
+        {
+            return HttpService.Get<Xframe>(Links.xframe, cancellationToken);
         }
     }
 }

--- a/UCWASDK/UCWASDK/Services/HttpService.cs
+++ b/UCWASDK/UCWASDK/Services/HttpService.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Skype.UCWA.Services
         {
             get
             {
-                if(_anonymousHttpClient == null)
+                if (_anonymousHttpClient == null)
                 {
                     _anonymousHttpClient = new HttpClient();
                     _anonymousHttpClient.DefaultRequestHeaders.TryAddWithoutValidation("Accept", "application/json");
@@ -164,11 +164,9 @@ namespace Microsoft.Skype.UCWA.Services
         {
             await ExecuteHttpCallAndRetry((token) => PutInternal(uri, body, token, version, anonymous), cancellationToken);
         }
-        private static List<CancellationTokenSource> ctss = new List<CancellationTokenSource>();
+        private static readonly CancellationTokenSource cts = new CancellationTokenSource();
         static internal CancellationToken GetNewCancellationToken()
         {
-            var cts = new CancellationTokenSource();
-            ctss.Add(cts);
             return cts.Token;
         }
         [Obsolete]
@@ -208,8 +206,7 @@ namespace Microsoft.Skype.UCWA.Services
         {
             foreach (var client in clientPool.Values)
                 client.Dispose();
-            foreach (var cts in ctss)
-                cts.Dispose();
+            cts.Dispose();
             clientPool.Clear();
             _anonymousHttpClient?.Dispose();
             _anonymousHttpClient = null;

--- a/UCWASDK/UCWASDK/Services/HttpService.cs
+++ b/UCWASDK/UCWASDK/Services/HttpService.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Skype.UCWA.Services
@@ -36,105 +37,167 @@ namespace Microsoft.Skype.UCWA.Services
         }
         static private ExceptionMappingService exceptionMappingService = new ExceptionMappingService();
 
-        static public async Task<T> Get<T>(UCWAHref href, string version = defaultVersion, bool anonymous = false) where T : UCWAModelBase
+        [Obsolete]
+        static public Task<T> Get<T>(UCWAHref href, string version = defaultVersion, bool anonymous = false) where T : UCWAModelBase
+        {
+            return Get<T>(href, GetNewCancellationToken(), version, anonymous);
+        }
+        static public async Task<T> Get<T>(UCWAHref href, CancellationToken cancellationToken, string version = defaultVersion, bool anonymous = false) where T : UCWAModelBase
         {
             if (href == null || string.IsNullOrEmpty(href.Href))
                 return default(T);
 
-            return await Get<T>(href.Href, version, anonymous);
+            return await Get<T>(href.Href, cancellationToken, version, anonymous);
         }
-        static public async Task<List<T>> GetList<T>(UCWAHref[] hrefs, string version = defaultVersion, bool anonymous = false) where T : UCWAModelBase
+        [Obsolete]
+        static public Task<List<T>> GetList<T>(UCWAHref[] hrefs, string version = defaultVersion, bool anonymous = false) where T : UCWAModelBase
+        {
+            return GetList<T>(hrefs, GetNewCancellationToken(), version, anonymous);
+        }
+        static public async Task<List<T>> GetList<T>(UCWAHref[] hrefs, CancellationToken cancellationToken, string version = defaultVersion, bool anonymous = false) where T : UCWAModelBase
         {
             if (hrefs == null || !hrefs.Any())
                 return null;
 
             List<T> list = new List<T>();
-            foreach (var href in hrefs) { if (!string.IsNullOrEmpty(href.Href)) list.Add(await Get<T>(href.Href, version, anonymous)); }
+            foreach (var href in hrefs) { if (!string.IsNullOrEmpty(href.Href)) list.Add(await Get<T>(href.Href, cancellationToken, version, anonymous)); }
 
             return list;
         }
-        static public async Task<T> Get<T>(string uri, string version = defaultVersion, bool anonymous = false) where T : UCWAModelBase
+        [Obsolete]
+        static public Task<T> Get<T>(string uri, string version = defaultVersion, bool anonymous = false) where T : UCWAModelBase
+        {
+            return Get<T>(uri, GetNewCancellationToken(), version, anonymous);
+        }
+        static public async Task<T> Get<T>(string uri, CancellationToken cancellationToken, string version = defaultVersion, bool anonymous = false) where T : UCWAModelBase
         {
             uri = EnsureUriContainsHttp(uri);
 
-            return await ExecuteHttpCallAndRetry(() => GetInternal(uri, version, anonymous), async (response) =>
-                {
-                    var jObject = JObject.Parse(await response.Content.ReadAsStringAsync());
-                    GetPGuid(jObject as JToken);
-                    return JsonConvert.DeserializeObject<T>(jObject.ToString());
-                });
+            return await ExecuteHttpCallAndRetry((token) => GetInternal(uri, token, version, anonymous), async (response) =>
+            {
+                var jObject = JObject.Parse(await response.Content.ReadAsStringAsync());
+                GetPGuid(jObject as JToken);
+                return JsonConvert.DeserializeObject<T>(jObject.ToString());
+            }, cancellationToken);
         }
-        static public async Task<HttpResponseMessage> GetInternal(string uri, string version = defaultVersion, bool anonymous = false)
+        static public async Task<HttpResponseMessage> GetInternal(string uri, CancellationToken cancellationToken, string version = defaultVersion, bool anonymous = false)
         {
             var client = await GetClient(uri, version, anonymous);
-            return await client.GetAsync(uri);
+            return await client.GetAsync(uri, cancellationToken);
         }
-        static public async Task<byte[]> GetBinary(UCWAHref href, string version = defaultVersion, bool anonymous = false)
+        [Obsolete]
+        static public Task<byte[]> GetBinary(UCWAHref href, string version = defaultVersion, bool anonymous = false)
+        {
+            return GetBinary(href, GetNewCancellationToken(), version, anonymous);
+        }
+        static public async Task<byte[]> GetBinary(UCWAHref href, CancellationToken cancellationToken, string version = defaultVersion, bool anonymous = false)
         {
             if (href == null || string.IsNullOrEmpty(href.Href))
                 return null;
 
             var uri = EnsureUriContainsHttp(href.Href);
 
-            return await ExecuteHttpCallAndRetry(() => GetInternal(uri, version, anonymous), async (response) =>
+            return await ExecuteHttpCallAndRetry((token) => GetInternal(uri, token, version, anonymous), async (response) =>
             {
                 return await response.Content.ReadAsByteArrayAsync();
-            });
+            }, cancellationToken);
         }
-        static public async Task<string> Post(UCWAHref href, object body, string version = defaultVersion, bool anonymous = false)
+        [Obsolete]
+        static public Task<string> Post(UCWAHref href, object body, string version = defaultVersion, bool anonymous = false)
+        {
+            return Post(href, body, GetNewCancellationToken(), version, anonymous);
+        }
+        static public async Task<string> Post(UCWAHref href, object body, CancellationToken cancellationToken, string version = defaultVersion, bool anonymous = false)
         {
             if (href == null || string.IsNullOrEmpty(href.Href))
                 return string.Empty;
 
-            return await Post(href.Href, body, version, anonymous);
+            return await Post(href.Href, body, cancellationToken, version, anonymous);
         }
-        static public async Task<string> Post(string uri, object body, string version = defaultVersion, bool anonymous = false)
+        [Obsolete]
+        static public Task<string> Post(string uri, object body, string version = defaultVersion, bool anonymous = false)
         {
-            return await ExecuteHttpCallAndRetry(() => PostInternal(uri, body, version, anonymous), (response) =>
+            return Post<string>(uri, body, GetNewCancellationToken(), version, anonymous);
+        }
+        static public async Task<string> Post(string uri, object body, CancellationToken cancellationToken, string version = defaultVersion, bool anonymous = false)
+        {
+            return await ExecuteHttpCallAndRetry((token) => PostInternal(uri, body, version, anonymous), (response) =>
             {
                 if (response.StatusCode == HttpStatusCode.Created)
                     return response.Headers.Location.ToString();
                 else
                     return string.Empty;
-            });
+            }, cancellationToken);
         }
-        static public async Task<T> Post<T>(UCWAHref href, object body, string version = defaultVersion, bool anonymous = false)
+        [Obsolete]
+        static public Task<T> Post<T>(UCWAHref href, object body, string version = defaultVersion, bool anonymous = false)
+        {
+            return Post<T>(href, body, GetNewCancellationToken(), version, anonymous);
+        }
+        static public async Task<T> Post<T>(UCWAHref href, object body, CancellationToken cancellationToken, string version = defaultVersion, bool anonymous = false)
         {
             if (href == null || string.IsNullOrEmpty(href.Href))
                 return default(T);
 
-            return await Post<T>(href.Href, body, version, anonymous);
+            return await Post<T>(href.Href, body, cancellationToken, version, anonymous);
         }
-        static public async Task<T> Post<T>(string uri, object body, string version = defaultVersion, bool anonymous = false)
+        [Obsolete]
+        static public Task<T> Post<T>(string uri, object body, string version = defaultVersion, bool anonymous = false)
         {
-            return await ExecuteHttpCallAndRetry(() => PostInternal(uri, body, version, anonymous), async (response) =>
+            return Post<T>(uri, body, GetNewCancellationToken(), version, anonymous);
+        }
+        static public async Task<T> Post<T>(string uri, object body, CancellationToken cancellationToken, string version = defaultVersion, bool anonymous = false)
+        {
+            return await ExecuteHttpCallAndRetry((token) => PostInternal(uri, body, version, anonymous), async (response) =>
             {
                 var jObject = JObject.Parse(await response.Content.ReadAsStringAsync());
                 GetPGuid(jObject as JToken);
                 return JsonConvert.DeserializeObject<T>(jObject.ToString());
-            });
+            }, cancellationToken);
         }
-        static public async Task Put(string uri, UCWAModelBase body, string version = defaultVersion, bool anonymous = false)
+        [Obsolete]
+        static public Task Put(string uri, UCWAModelBase body, string version = defaultVersion, bool anonymous = false)
         {
-            await ExecuteHttpCallAndRetry(() => PutInternal(uri, body, version, anonymous));
+            return Put(uri, body, GetNewCancellationToken(), version, anonymous);
         }
-        static public async Task<T> Put<T>(string uri, UCWAModelBase body, string version = defaultVersion, bool anonymous = false)
+        static public async Task Put(string uri, UCWAModelBase body, CancellationToken cancellationToken, string version = defaultVersion, bool anonymous = false)
         {
-            return await ExecuteHttpCallAndRetry(() => PutInternal(uri, body, version, anonymous), async (response) =>
+            await ExecuteHttpCallAndRetry((token) => PutInternal(uri, body, version, anonymous), cancellationToken);
+        }
+        private static List<CancellationTokenSource> ctss = new List<CancellationTokenSource>();
+        static internal CancellationToken GetNewCancellationToken()
+        {
+            var cts = new CancellationTokenSource();
+            ctss.Add(cts);
+            return cts.Token;
+        }
+        [Obsolete]
+        static public Task<T> Put<T>(string uri, UCWAModelBase body, string version = defaultVersion, bool anonymous = false)
+        {
+            return Put<T>(uri, body, GetNewCancellationToken(), version, anonymous);
+        }
+        static public async Task<T> Put<T>(string uri, UCWAModelBase body, CancellationToken cancellationToken, string version = defaultVersion, bool anonymous = false)
+        {
+            return await ExecuteHttpCallAndRetry((token) => PutInternal(uri, body, version, anonymous), async (response) =>
             {
                 var jObject = JObject.Parse(await response.Content.ReadAsStringAsync());
                 GetPGuid(jObject as JToken);
                 return JsonConvert.DeserializeObject<T>(jObject.ToString());
-            });
+            }, cancellationToken);
         }
-        static public async Task Delete(string uri, string version = defaultVersion, bool anonymous = false)
+        [Obsolete]
+        static public Task Delete(string uri, string version = defaultVersion, bool anonymous = false)
+        {
+            return Delete(uri, GetNewCancellationToken(), version, anonymous);
+        }
+        static public async Task Delete(string uri, CancellationToken cancellationToken, string version = defaultVersion, bool anonymous = false)
         {
             if (string.IsNullOrEmpty(uri))
                 return;
 
             uri = EnsureUriContainsHttp(uri);
 
-            await ExecuteHttpCallAndRetry(() => DeleteInternal(uri, version, anonymous));
+            await ExecuteHttpCallAndRetry((token) => DeleteInternal(uri, version, anonymous), cancellationToken);
         }
         static public async Task<HttpResponseMessage> DeleteInternal(string uri, string version = defaultVersion, bool anonymous = false)
         {
@@ -145,6 +208,8 @@ namespace Microsoft.Skype.UCWA.Services
         {
             foreach (var client in clientPool.Values)
                 client.Dispose();
+            foreach (var cts in ctss)
+                cts.Dispose();
             clientPool.Clear();
             _anonymousHttpClient?.Dispose();
             _anonymousHttpClient = null;
@@ -211,14 +276,14 @@ namespace Microsoft.Skype.UCWA.Services
             request.Headers.Add("If-Match", "\"" + body.ETag + "\"");
             return await client.SendAsync(request);
         }
-        static private async Task ExecuteHttpCallAndRetry(Func<Task<HttpResponseMessage>> httpRequest, Action<HttpResponseMessage> deserializationHandler = null)
+        static private async Task ExecuteHttpCallAndRetry(Func<CancellationToken, Task<HttpResponseMessage>> httpRequest, CancellationToken cancellationToken, Action<HttpResponseMessage> deserializationHandler = null)
         {
             var retryCount = 0U;
             Exception lastException = null;
             do
                 try
                 {
-                    var response = await httpRequest();
+                    var response = await httpRequest(cancellationToken);
                     if (response.IsSuccessStatusCode)
                     {
                         deserializationHandler?.Invoke(response);
@@ -235,20 +300,20 @@ namespace Microsoft.Skype.UCWA.Services
                     await Task.Delay(Settings.UCWAClient.TransientErrorHandlingPolicy.GetNextErrorWaitTimeInMs(retryCount));
                     retryCount++;
                 }
-            while (Settings.UCWAClient.TransientErrorHandlingPolicy.ShouldRetry(retryCount));
+            while (Settings.UCWAClient.TransientErrorHandlingPolicy.ShouldRetry(retryCount) && !cancellationToken.IsCancellationRequested);
 
             if (lastException != null)
                 throw lastException;
 
         }
-        static private async Task<T> ExecuteHttpCallAndRetry<T>(Func<Task<HttpResponseMessage>> httpRequest, Func<HttpResponseMessage, Task<T>> deserializationHandler)
+        static private async Task<T> ExecuteHttpCallAndRetry<T>(Func<CancellationToken, Task<HttpResponseMessage>> httpRequest, Func<HttpResponseMessage, Task<T>> deserializationHandler, CancellationToken cancellationToken)
         {
             var retryCount = 0U;
             Exception lastException = null;
             do
                 try
                 {
-                    var response = await httpRequest();
+                    var response = await httpRequest(cancellationToken);
                     if (response.IsSuccessStatusCode)
                         return await deserializationHandler(response);
                     else
@@ -262,21 +327,21 @@ namespace Microsoft.Skype.UCWA.Services
                     await Task.Delay(Settings.UCWAClient.TransientErrorHandlingPolicy.GetNextErrorWaitTimeInMs(retryCount));
                     retryCount++;
                 }
-            while (Settings.UCWAClient.TransientErrorHandlingPolicy.ShouldRetry(retryCount));
+            while (Settings.UCWAClient.TransientErrorHandlingPolicy.ShouldRetry(retryCount) && !cancellationToken.IsCancellationRequested);
 
             if (lastException != null)
                 throw lastException;
 
             return default(T); // this line is never going to be executed because previous one always throws an error
         }
-        static private async Task<T> ExecuteHttpCallAndRetry<T>(Func<Task<HttpResponseMessage>> httpRequest, Func<HttpResponseMessage, T> deserializationHandler)
+        static private async Task<T> ExecuteHttpCallAndRetry<T>(Func<CancellationToken, Task<HttpResponseMessage>> httpRequest, Func<HttpResponseMessage, T> deserializationHandler, CancellationToken cancellationToken)
         {
             var retryCount = 0U;
             Exception lastException = null;
             do
                 try
                 {
-                    var response = await httpRequest();
+                    var response = await httpRequest(cancellationToken);
                     if (response.IsSuccessStatusCode)
                         return deserializationHandler(response);
                     else
@@ -290,7 +355,7 @@ namespace Microsoft.Skype.UCWA.Services
                     await Task.Delay(Settings.UCWAClient.TransientErrorHandlingPolicy.GetNextErrorWaitTimeInMs(retryCount));
                     retryCount++;
                 }
-            while (Settings.UCWAClient.TransientErrorHandlingPolicy.ShouldRetry(retryCount));
+            while (Settings.UCWAClient.TransientErrorHandlingPolicy.ShouldRetry(retryCount) && !cancellationToken.IsCancellationRequested);
 
             if (lastException != null)
                 throw lastException;

--- a/UCWASDK/UCWASDK/UCWAClient.cs
+++ b/UCWASDK/UCWASDK/UCWAClient.cs
@@ -1028,15 +1028,23 @@ namespace Microsoft.Skype.UCWA
             PhoneAudio phoneAudio = await conversation?.GetPhoneAudio(cancellationToken);
             await phoneAudio?.AddPhoneAudio(sip, phoneNumber);
         }
-
         /// <summary>
         /// Reply message to existing Messaging by using Message.
         /// </summary>
         /// <param name="text">Reply message text.</param>
         /// <param name="message">Message</param>
-        public async Task ReplyMessage(string text, Message message)
+        public Task ReplyMessage(string text, Message message)
         {
-            Messaging messaging = await message.GetMessaging();
+            return ReplyMessage(text, message, _cancellationTokenSource.Token);
+        }
+        /// <summary>
+        /// Reply message to existing Messaging by using Message.
+        /// </summary>
+        /// <param name="text">Reply message text.</param>
+        /// <param name="message">Message</param>
+        public async Task ReplyMessage(string text, Message message, CancellationToken cancellationToken)
+        {
+            Messaging messaging = await message.GetMessaging(cancellationToken);
             await messaging?.SendMessage(text);
         }
 

--- a/UCWASDK/UCWASDK/UCWAClient.cs
+++ b/UCWASDK/UCWASDK/UCWAClient.cs
@@ -890,72 +890,130 @@ namespace Microsoft.Skype.UCWA
             MyOnlineMeetings myOnlineMeetings = await application.OnlineMeetings.GetMyOnlineMeetings();
             return await myOnlineMeetings.Create(myOnlineMeeting);
         }
-
         /// <summary>
         /// Add instant message capability to existing conversation.
         /// </summary>
         /// <param name="conversation">Conversation to add messaging.</param>
         /// <param name="message">Initial message.</param>
-        public async Task AddMessaging(Conversation conversation, string message = "")
+        public Task AddMessaging(Conversation conversation, string message = "")
         {
-            Messaging messaging = await conversation.GetMessaging();
+            return AddMessaging(conversation, _cancellationTokenSource.Token, message);
+        }
+        /// <summary>
+        /// Add instant message capability to existing conversation.
+        /// </summary>
+        /// <param name="conversation">Conversation to add messaging.</param>
+        /// <param name="message">Initial message.</param>
+        public async Task AddMessaging(Conversation conversation, CancellationToken cancellationToken, string message = "")
+        {
+            Messaging messaging = await conversation.GetMessaging(cancellationToken);
             await messaging?.AddMessaging(MessageFormat.Plain, message);
         }
-
         /// <summary>
         /// Add instant message capability to existing conversation by using OnlineMeetingInvitation.
         /// </summary>
         /// <param name="onlineMeetingInvitation">OnlineMeetingInvitation</param>
         /// <param name="message">Initial message.</param>
-        public async Task AddMessaging(OnlineMeetingInvitation onlineMeetingInvitation, string message = "")
+        public Task AddMessaging(OnlineMeetingInvitation onlineMeetingInvitation, string message = "")
         {
-            Conversation conversation = await onlineMeetingInvitation.GetConversation();
-            Messaging messaging = await conversation?.GetMessaging();
+            return AddMessaging(onlineMeetingInvitation, _cancellationTokenSource.Token, message);
+        }
+        /// <summary>
+        /// Add instant message capability to existing conversation by using OnlineMeetingInvitation.
+        /// </summary>
+        /// <param name="onlineMeetingInvitation">OnlineMeetingInvitation</param>
+        /// <param name="message">Initial message.</param>
+        public async Task AddMessaging(OnlineMeetingInvitation onlineMeetingInvitation, CancellationToken cancellationToken, string message = "")
+        {
+            Conversation conversation = await onlineMeetingInvitation.GetConversation(cancellationToken);
+            Messaging messaging = await conversation?.GetMessaging(cancellationToken);
             await messaging?.AddMessaging(MessageFormat.Plain, message);
         }
-
         /// <summary>
         /// Add a participant to existing conversation.
         /// </summary>
         /// <param name="sip">Contact's sip. Use Uri property for Contact object.</param>
         /// <param name="conversation">Conversation to add participant.</param>
-        public async Task AddParticipant(string sip, Conversation conversation)
+        public Task AddParticipant(string sip, Conversation conversation)
         {
-            await conversation.AddParticipant(sip);
+            return AddParticipant(sip, conversation, _cancellationTokenSource.Token);
         }
-
+        /// <summary>
+        /// Add a participant to existing conversation.
+        /// </summary>
+        /// <param name="sip">Contact's sip. Use Uri property for Contact object.</param>
+        /// <param name="conversation">Conversation to add participant.</param>
+        public async Task AddParticipant(string sip, Conversation conversation, CancellationToken cancellationToken)
+        {
+            await conversation.AddParticipant(sip, cancellationToken);
+        }
         /// <summary>
         /// Add a participant to existing conversation by using message.
         /// </summary>
         /// <param name="sip">Contact's sip. Use Uri property for Contact object.</param>
         /// <param name="message">Message to add participant.</param>
-        public async Task AddParticipant(string sip, Message message)
+        public Task AddParticipant(string sip, Message message)
         {
-            Messaging messaging = await message.GetMessaging();
-            Conversation conversation = await messaging?.GetConversation();
-            await conversation?.AddParticipant(sip);
+            return AddParticipant(sip, message, _cancellationTokenSource.Token);
         }
-
+        /// <summary>
+        /// Add a participant to existing conversation by using message.
+        /// </summary>
+        /// <param name="sip">Contact's sip. Use Uri property for Contact object.</param>
+        /// <param name="message">Message to add participant.</param>
+        public async Task AddParticipant(string sip, Message message, CancellationToken cancellationToken)
+        {
+            Messaging messaging = await message.GetMessaging(cancellationToken);
+            Conversation conversation = await messaging?.GetConversation(cancellationToken);
+            await conversation?.AddParticipant(sip, cancellationToken);
+        }
         /// <summary>
         /// Add a participant to existing conversation by using onlineMeetingInvitation.
         /// </summary>
         /// <param name="sip">Contact's sip. Use Uri property for Contact object.</param>
         /// <param name="onlineMeetingInvitation">OnlineMeetingInvitation to add participant.</param>
-        public async Task AddParticipant(string sip, OnlineMeetingInvitation onlineMeetingInvitation)
+        public Task AddParticipant(string sip, OnlineMeetingInvitation onlineMeetingInvitation)
         {
-            Conversation conversation = await onlineMeetingInvitation.GetConversation();
-            await conversation?.AddParticipant(sip);
+            return AddParticipant(sip, onlineMeetingInvitation, _cancellationTokenSource.Token);
         }
-
+        /// <summary>
+        /// Add a participant to existing conversation by using onlineMeetingInvitation.
+        /// </summary>
+        /// <param name="sip">Contact's sip. Use Uri property for Contact object.</param>
+        /// <param name="onlineMeetingInvitation">OnlineMeetingInvitation to add participant.</param>
+        public async Task AddParticipant(string sip, OnlineMeetingInvitation onlineMeetingInvitation, CancellationToken cancellationToken)
+        {
+            Conversation conversation = await onlineMeetingInvitation.GetConversation(cancellationToken);
+            await conversation?.AddParticipant(sip, cancellationToken);
+        }
         /// <summary>
         /// Add a participant to existing conversation by using MessagingInvitation.
         /// </summary>
         /// <param name="sip">Contact's sip. Use Uri property for Contact object.</param>
         /// <param name="messagingInvitation">MessagingInvitation to add participant.</param>
-        public async Task AddParticipant(string sip, MessagingInvitation messagingInvitation)
+        public Task AddParticipant(string sip, MessagingInvitation messagingInvitation)
         {
-            Conversation conversation = await messagingInvitation.GetConversation();
-            await conversation.AddParticipant(sip);
+            return AddParticipant(sip, messagingInvitation, _cancellationTokenSource.Token);
+        }
+        /// <summary>
+        /// Add a participant to existing conversation by using MessagingInvitation.
+        /// </summary>
+        /// <param name="sip">Contact's sip. Use Uri property for Contact object.</param>
+        /// <param name="messagingInvitation">MessagingInvitation to add participant.</param>
+        public async Task AddParticipant(string sip, MessagingInvitation messagingInvitation, CancellationToken cancellationToken)
+        {
+            Conversation conversation = await messagingInvitation.GetConversation(cancellationToken);
+            await conversation.AddParticipant(sip, cancellationToken);
+        }
+        /// <summary>
+        /// Add Phone Call to existing conversation by using OnlineMeetingInvitation.
+        /// </summary>
+        /// <param name="sip">Contact's sip. Use Uri property for Contact object.</param>
+        /// <param name="phoneNumber">Phone number.</param>
+        /// <param name="onlineMeetingInvitation">OnlineMeetingInvitation</param>
+        public Task AddPhoneCall(string sip, string phoneNumber, OnlineMeetingInvitation onlineMeetingInvitation)
+        {
+            return AddPhoneCall(sip, phoneNumber, onlineMeetingInvitation, _cancellationTokenSource.Token);
         }
 
         /// <summary>
@@ -964,10 +1022,10 @@ namespace Microsoft.Skype.UCWA
         /// <param name="sip">Contact's sip. Use Uri property for Contact object.</param>
         /// <param name="phoneNumber">Phone number.</param>
         /// <param name="onlineMeetingInvitation">OnlineMeetingInvitation</param>
-        public async Task AddPhoneCall(string sip, string phoneNumber, OnlineMeetingInvitation onlineMeetingInvitation)
+        public async Task AddPhoneCall(string sip, string phoneNumber, OnlineMeetingInvitation onlineMeetingInvitation, CancellationToken cancellationToken)
         {
-            Conversation conversation = await onlineMeetingInvitation.GetConversation();
-            PhoneAudio phoneAudio = await conversation?.GetPhoneAudio();
+            Conversation conversation = await onlineMeetingInvitation.GetConversation(cancellationToken);
+            PhoneAudio phoneAudio = await conversation?.GetPhoneAudio(cancellationToken);
             await phoneAudio?.AddPhoneAudio(sip, phoneNumber);
         }
 
@@ -987,9 +1045,18 @@ namespace Microsoft.Skype.UCWA
         /// </summary>
         /// <param name="text">Reply message text.</param>
         /// <param name="conversation">Conversation</param>
-        public async Task ReplyMessage(string text, Conversation conversation)
+        public Task ReplyMessage(string text, Conversation conversation)
         {
-            Messaging messaging = await conversation.GetMessaging();
+            return ReplyMessage(text, conversation, _cancellationTokenSource.Token);
+        }
+        /// <summary>
+        /// Reply message to existing Messaging by using Conversation.
+        /// </summary>
+        /// <param name="text">Reply message text.</param>
+        /// <param name="conversation">Conversation</param>
+        public async Task ReplyMessage(string text, Conversation conversation, CancellationToken cancellationToken)
+        {
+            Messaging messaging = await conversation.GetMessaging(cancellationToken);
             await messaging?.SendMessage(text);
         }
 
@@ -1003,16 +1070,24 @@ namespace Microsoft.Skype.UCWA
             Messaging messaging = await messagingInvitation.GetMessaging();
             await messaging?.SendMessage(text);
         }
-
+        // <summary>
+        /// Reply message to existing Messaging by using OnlineMeetingInvitation.
+        /// </summary>
+        /// <param name="text">Reply message text.</param>
+        /// <param name="onlineMeetingInvitation">OnlineMeetingInvitation</param>
+        public Task ReplyMessage(string text, OnlineMeetingInvitation onlineMeetingInvitation)
+        {
+            return ReplyMessage(text, onlineMeetingInvitation, _cancellationTokenSource.Token);
+        }
         /// <summary>
         /// Reply message to existing Messaging by using OnlineMeetingInvitation.
         /// </summary>
         /// <param name="text">Reply message text.</param>
         /// <param name="onlineMeetingInvitation">OnlineMeetingInvitation</param>
-        public async Task ReplyMessage(string text, OnlineMeetingInvitation onlineMeetingInvitation)
+        public async Task ReplyMessage(string text, OnlineMeetingInvitation onlineMeetingInvitation, CancellationToken cancellationToken)
         {
-            Conversation conversation = await onlineMeetingInvitation.GetConversation();
-            Messaging messaging = await conversation?.GetMessaging();
+            Conversation conversation = await onlineMeetingInvitation.GetConversation(cancellationToken);
+            Messaging messaging = await conversation?.GetMessaging(cancellationToken);
             await messaging?.SendMessage(text);
         }
 

--- a/UCWASDK/UCWASDK/UCWAClient.cs
+++ b/UCWASDK/UCWASDK/UCWAClient.cs
@@ -919,7 +919,7 @@ namespace Microsoft.Skype.UCWA
         /// <returns>Created MyOnlineMeeting</returns>
         public async Task<MyOnlineMeeting> CreateScheduledOnlineMeeting(MyOnlineMeeting myOnlineMeeting, CancellationToken cancellationToken)
         {
-            MyOnlineMeetings myOnlineMeetings = await application.OnlineMeetings.GetMyOnlineMeetings();
+            MyOnlineMeetings myOnlineMeetings = await application.OnlineMeetings.GetMyOnlineMeetings(cancellationToken);
             return await myOnlineMeetings.Create(myOnlineMeeting, cancellationToken);
         }
         /// <summary>

--- a/UCWASDK/UCWASDK/UCWAClient.cs
+++ b/UCWASDK/UCWASDK/UCWAClient.cs
@@ -761,7 +761,7 @@ namespace Microsoft.Skype.UCWA
             {
                 PresenceSubscription presenceSubscription = presenceSubscriptions.Subscriptions.FirstOrDefault(x => x.Id == sip);
                 if (presenceSubscription != null)
-                    await presenceSubscription.Delete();
+                    await presenceSubscription.Delete(_cancellationTokenSource.Token);
             }
         }
 
@@ -1197,7 +1197,7 @@ namespace Microsoft.Skype.UCWA
                 {
                     var root = JsonConvert.DeserializeObject<Root>(await response.Content.ReadAsStringAsync(), new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Include });
                     var redirect = await root.GetRedirect(_cancellationTokenSource.Token);
-                    return await (redirect?.GetUser() ?? root.GetUser(_cancellationTokenSource.Token));
+                    return await (redirect?.GetUser(_cancellationTokenSource.Token) ?? root.GetUser(_cancellationTokenSource.Token));
                 }
                 else
                     return null;

--- a/UCWASDK/UCWASDK/UCWAClient.cs
+++ b/UCWASDK/UCWASDK/UCWAClient.cs
@@ -1045,7 +1045,7 @@ namespace Microsoft.Skype.UCWA
         public async Task ReplyMessage(string text, Message message, CancellationToken cancellationToken)
         {
             Messaging messaging = await message.GetMessaging(cancellationToken);
-            await messaging?.SendMessage(text);
+            await messaging?.SendMessage(text, cancellationToken);
         }
 
         /// <summary>
@@ -1065,7 +1065,7 @@ namespace Microsoft.Skype.UCWA
         public async Task ReplyMessage(string text, Conversation conversation, CancellationToken cancellationToken)
         {
             Messaging messaging = await conversation.GetMessaging(cancellationToken);
-            await messaging?.SendMessage(text);
+            await messaging?.SendMessage(text, cancellationToken);
         }
         /// <summary>
         /// Reply message to existing Messaging by using MessagingInvitation.
@@ -1084,7 +1084,7 @@ namespace Microsoft.Skype.UCWA
         public async Task ReplyMessage(string text, MessagingInvitation messagingInvitation, CancellationToken cancellationToken)
         {
             Messaging messaging = await messagingInvitation.GetMessaging(cancellationToken);
-            await messaging?.SendMessage(text);
+            await messaging?.SendMessage(text, cancellationToken);
         }
         // <summary>
         /// Reply message to existing Messaging by using OnlineMeetingInvitation.
@@ -1104,7 +1104,7 @@ namespace Microsoft.Skype.UCWA
         {
             Conversation conversation = await onlineMeetingInvitation.GetConversation(cancellationToken);
             Messaging messaging = await conversation?.GetMessaging(cancellationToken);
-            await messaging?.SendMessage(text);
+            await messaging?.SendMessage(text, cancellationToken);
         }
 
         #endregion

--- a/UCWASDK/UCWASDK/UCWAClient.cs
+++ b/UCWASDK/UCWASDK/UCWAClient.cs
@@ -1309,12 +1309,12 @@ namespace Microsoft.Skype.UCWA
             }
         }
 
-        internal async Task GetToken(HttpClient client, string uri)
+        internal async Task GetToken(HttpClient client, string uri, CancellationToken cancellationToken)
         {
             SendingRequest(client, uri);
             while (client.DefaultRequestHeaders.Authorization == null)
             {
-                await Task.Delay(100);
+                await Task.Delay(100, cancellationToken);
             }
         }
 

--- a/UCWASDK/UCWASDK/UCWAClient.cs
+++ b/UCWASDK/UCWASDK/UCWAClient.cs
@@ -1196,8 +1196,8 @@ namespace Microsoft.Skype.UCWA
                 if (response.IsSuccessStatusCode)
                 {
                     var root = JsonConvert.DeserializeObject<Root>(await response.Content.ReadAsStringAsync(), new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Include });
-                    var redirect = await root.GetRedirect();
-                    return await (redirect?.GetUser() ?? root.GetUser());
+                    var redirect = await root.GetRedirect(_cancellationTokenSource.Token);
+                    return await (redirect?.GetUser() ?? root.GetUser(_cancellationTokenSource.Token));
                 }
                 else
                     return null;

--- a/UCWASDK/UCWASDK/UCWAClient.cs
+++ b/UCWASDK/UCWASDK/UCWAClient.cs
@@ -907,7 +907,7 @@ namespace Microsoft.Skype.UCWA
         public async Task AddMessaging(Conversation conversation, CancellationToken cancellationToken, string message = "")
         {
             Messaging messaging = await conversation.GetMessaging(cancellationToken);
-            await messaging?.AddMessaging(MessageFormat.Plain, message);
+            await messaging?.AddMessaging(MessageFormat.Plain, message, cancellationToken);
         }
         /// <summary>
         /// Add instant message capability to existing conversation by using OnlineMeetingInvitation.
@@ -927,7 +927,7 @@ namespace Microsoft.Skype.UCWA
         {
             Conversation conversation = await onlineMeetingInvitation.GetConversation(cancellationToken);
             Messaging messaging = await conversation?.GetMessaging(cancellationToken);
-            await messaging?.AddMessaging(MessageFormat.Plain, message);
+            await messaging?.AddMessaging(MessageFormat.Plain, message, cancellationToken);
         }
         /// <summary>
         /// Add a participant to existing conversation.

--- a/UCWASDK/UCWASDK/UCWAClient.cs
+++ b/UCWASDK/UCWASDK/UCWAClient.cs
@@ -773,7 +773,7 @@ namespace Microsoft.Skype.UCWA
         public async Task<PresenceSubscription> SubscribeContactsChange(CancellationToken cancellationToken, params string[] sips)
         {
             PresenceSubscriptions presenceSubscriptions = await application.People.GetPresenceSubscriptions(cancellationToken);
-            return await presenceSubscriptions.SubscribeToContactsPresence(sips, 30);
+            return await presenceSubscriptions.SubscribeToContactsPresence(cancellationToken, sips, 30);
         }
         /// <summary>
         /// Unsubscribe to Contact Change.
@@ -1091,7 +1091,7 @@ namespace Microsoft.Skype.UCWA
         {
             Conversation conversation = await onlineMeetingInvitation.GetConversation(cancellationToken);
             PhoneAudio phoneAudio = await conversation?.GetPhoneAudio(cancellationToken);
-            await phoneAudio?.AddPhoneAudio(sip, phoneNumber);
+            await phoneAudio?.AddPhoneAudio(sip, phoneNumber, _cancellationTokenSource.Token);
         }
         /// <summary>
         /// Reply message to existing Messaging by using Message.

--- a/UCWASDK/UCWASDK/UCWAClient.cs
+++ b/UCWASDK/UCWASDK/UCWAClient.cs
@@ -770,20 +770,37 @@ namespace Microsoft.Skype.UCWA
         /// </summary>
         /// <param name="sip">Contact's sip. Use Uri property for Contact object.</param>
         /// <param name="groupId">Id of group.</param>
-        public async Task AddContactToGroup(string sip, string groupId)
+        public Task AddContactToGroup(string sip, string groupId)
         {
-            MyGroupMemberships2 myGroupMemberships = await application.People.GetMyGroupMemberships(_cancellationTokenSource.Token);
-            await myGroupMemberships.AddContact(sip, groupId);
+            return AddContactToGroup(sip, groupId, _cancellationTokenSource.Token);
+        }
+        /// <summary>
+        /// Add a contact to specified group.
+        /// </summary>
+        /// <param name="sip">Contact's sip. Use Uri property for Contact object.</param>
+        /// <param name="groupId">Id of group.</param>
+        public async Task AddContactToGroup(string sip, string groupId, CancellationToken cancellationToken)
+        {
+            MyGroupMemberships2 myGroupMemberships = await application.People.GetMyGroupMemberships(cancellationToken);
+            await myGroupMemberships.AddContact(sip, groupId, cancellationToken);
         }
 
         /// <summary>
         /// Removed a contact from all groups.
         /// </summary>
         /// <param name="sip">Contact's sip. Use Uri property for Contact object.</param>
-        public async Task RemoveContactFromAllGroup(string sip)
+        public Task RemoveContactFromAllGroup(string sip)
         {
-            MyGroupMemberships2 myGroupMemberships = await application.People.GetMyGroupMemberships(_cancellationTokenSource.Token);
-            await myGroupMemberships.RemoveContactFromAllGroups(sip);
+            return RemoveContactFromAllGroup(sip, _cancellationTokenSource.Token);
+        }
+        /// <summary>
+        /// Removed a contact from all groups.
+        /// </summary>
+        /// <param name="sip">Contact's sip. Use Uri property for Contact object.</param>
+        public async Task RemoveContactFromAllGroup(string sip, CancellationToken cancellationToken)
+        {
+            MyGroupMemberships2 myGroupMemberships = await application.People.GetMyGroupMemberships(cancellationToken);
+            await myGroupMemberships.RemoveContactFromAllGroups(sip, cancellationToken);
         }
 
         /// <summary>

--- a/UCWASDK/UCWASDK/UCWAClient.cs
+++ b/UCWASDK/UCWASDK/UCWAClient.cs
@@ -802,15 +802,22 @@ namespace Microsoft.Skype.UCWA
             MyGroupMemberships2 myGroupMemberships = await application.People.GetMyGroupMemberships(cancellationToken);
             await myGroupMemberships.RemoveContactFromAllGroups(sip, cancellationToken);
         }
-
         /// <summary>
         /// Create new group.
         /// </summary>
         /// <param name="groupName">Group name</param>
-        public async Task CreateGroup(string groupName)
+        public Task CreateGroup(string groupName)
         {
-            var myGroups = await application.People.GetMyGroups();
-            await myGroups.CreateGroup(groupName);
+            return CreateGroup(groupName, _cancellationTokenSource.Token);
+        }
+        /// <summary>
+        /// Create new group.
+        /// </summary>
+        /// <param name="groupName">Group name</param>
+        public async Task CreateGroup(string groupName, CancellationToken cancellationToken)
+        {
+            var myGroups = await application.People.GetMyGroups(cancellationToken);
+            await myGroups.CreateGroup(groupName, cancellationToken);
         }
 
         #endregion
@@ -896,16 +903,24 @@ namespace Microsoft.Skype.UCWA
         {
             await application.Communication.StartOnlineMeeting(subject, importance, cancellationToken);
         }
-
         /// <summary>
         /// Create Scheduled Online Meeting
         /// </summary>
         /// <param name="myOnlineMeeting">MyOnlineMeeting</param>
         /// <returns>Created MyOnlineMeeting</returns>
-        public async Task<MyOnlineMeeting> CreateScheduledOnlineMeeting(MyOnlineMeeting myOnlineMeeting)
+        public Task<MyOnlineMeeting> CreateScheduledOnlineMeeting(MyOnlineMeeting myOnlineMeeting)
+        {
+            return CreateScheduledOnlineMeeting(myOnlineMeeting, _cancellationTokenSource.Token);
+        }
+        /// <summary>
+        /// Create Scheduled Online Meeting
+        /// </summary>
+        /// <param name="myOnlineMeeting">MyOnlineMeeting</param>
+        /// <returns>Created MyOnlineMeeting</returns>
+        public async Task<MyOnlineMeeting> CreateScheduledOnlineMeeting(MyOnlineMeeting myOnlineMeeting, CancellationToken cancellationToken)
         {
             MyOnlineMeetings myOnlineMeetings = await application.OnlineMeetings.GetMyOnlineMeetings();
-            return await myOnlineMeetings.Create(myOnlineMeeting);
+            return await myOnlineMeetings.Create(myOnlineMeeting, cancellationToken);
         }
         /// <summary>
         /// Add instant message capability to existing conversation.

--- a/UCWASDK/UCWASDK/UCWAClient.cs
+++ b/UCWASDK/UCWASDK/UCWAClient.cs
@@ -736,7 +736,7 @@ namespace Microsoft.Skype.UCWA
         /// <returns>Search result as Search2 model</returns>
         public async Task<Search2> Search(string query)
         {
-            return await application.People.Search(query);
+            return await application.People.Search(query, _cancellationTokenSource.Token);
         }
 
         /// <summary>
@@ -746,7 +746,7 @@ namespace Microsoft.Skype.UCWA
         /// <returns>PresenceSubscription</returns>
         public async Task<PresenceSubscription> SubscribeContactsChange(params string[] sips)
         {
-            PresenceSubscriptions presenceSubscriptions = await application.People.GetPresenceSubscriptions();
+            PresenceSubscriptions presenceSubscriptions = await application.People.GetPresenceSubscriptions(_cancellationTokenSource.Token);
             return await presenceSubscriptions.SubscribeToContactsPresence(sips, 30);
         }
 
@@ -756,7 +756,7 @@ namespace Microsoft.Skype.UCWA
         /// <param name="sips">sip names to unsubscribe.</param>
         public async Task UnSubscribeContactsChange(params string[] sips)
         {
-            PresenceSubscriptions presenceSubscriptions = await application.People.GetPresenceSubscriptions();
+            PresenceSubscriptions presenceSubscriptions = await application.People.GetPresenceSubscriptions(_cancellationTokenSource.Token);
             foreach (var sip in sips)
             {
                 PresenceSubscription presenceSubscription = presenceSubscriptions.Subscriptions.FirstOrDefault(x => x.Id == sip);
@@ -772,7 +772,7 @@ namespace Microsoft.Skype.UCWA
         /// <param name="groupId">Id of group.</param>
         public async Task AddContactToGroup(string sip, string groupId)
         {
-            MyGroupMemberships2 myGroupMemberships = await application.People.GetMyGroupMemberships();
+            MyGroupMemberships2 myGroupMemberships = await application.People.GetMyGroupMemberships(_cancellationTokenSource.Token);
             await myGroupMemberships.AddContact(sip, groupId);
         }
 
@@ -782,7 +782,7 @@ namespace Microsoft.Skype.UCWA
         /// <param name="sip">Contact's sip. Use Uri property for Contact object.</param>
         public async Task RemoveContactFromAllGroup(string sip)
         {
-            MyGroupMemberships2 myGroupMemberships = await application.People.GetMyGroupMemberships();
+            MyGroupMemberships2 myGroupMemberships = await application.People.GetMyGroupMemberships(_cancellationTokenSource.Token);
             await myGroupMemberships.RemoveContactFromAllGroups(sip);
         }
 
@@ -1117,7 +1117,7 @@ namespace Microsoft.Skype.UCWA
             if (user == null)
                 return false;
 
-            application = await user.CreateApplication(agentName, Guid.NewGuid().ToString(), language);
+            application = await user.CreateApplication(agentName, Guid.NewGuid().ToString(), language, _cancellationTokenSource.Token);
 
             // Get host address
             Settings.Host = new Uri(user.Self).Scheme + "://" + new Uri(user.Self).Host;

--- a/UCWASDK/UCWASDK/UCWAClient.cs
+++ b/UCWASDK/UCWASDK/UCWAClient.cs
@@ -1067,15 +1067,23 @@ namespace Microsoft.Skype.UCWA
             Messaging messaging = await conversation.GetMessaging(cancellationToken);
             await messaging?.SendMessage(text);
         }
-
         /// <summary>
         /// Reply message to existing Messaging by using MessagingInvitation.
         /// </summary>
         /// <param name="text">Reply message text.</param>
         /// <param name="messagingInvitation">MessagingInvitation</param>
-        public async Task ReplyMessage(string text, MessagingInvitation messagingInvitation)
+        public Task ReplyMessage(string text, MessagingInvitation messagingInvitation)
         {
-            Messaging messaging = await messagingInvitation.GetMessaging();
+            return ReplyMessage(text, messagingInvitation, _cancellationTokenSource.Token);
+        }
+        /// <summary>
+        /// Reply message to existing Messaging by using MessagingInvitation.
+        /// </summary>
+        /// <param name="text">Reply message text.</param>
+        /// <param name="messagingInvitation">MessagingInvitation</param>
+        public async Task ReplyMessage(string text, MessagingInvitation messagingInvitation, CancellationToken cancellationToken)
+        {
+            Messaging messaging = await messagingInvitation.GetMessaging(cancellationToken);
             await messaging?.SendMessage(text);
         }
         // <summary>


### PR DESCRIPTION
Hi @kenakamu ,
@2toLeadMike and myself put together this pull request.
it's rather big even if a big part of the changes are only exposing new methods and relaying the cancellation token.
That PR brings two major improvements:
- ability to pass the cancellation token all the way down, so if the process is interrupted for some reason, all network requests that are ongoing will be as well
- implemented retry policy for http timeout (which throws a task canceled exception for some reason https://stackoverflow.com/questions/10547895/how-can-i-tell-when-httpclient-has-timed-out)

I understand it's a rather big PR, and we'd need this PR to be reviewed, merged and the nuget to be published fairly quickly if possible. We're approaching production deployment for one of our major projects.
Thanks! And let me know if you have any question. :)