### PR TITLE
Fix Memberships Property

### DIFF
--- a/UCWASDK/UCWASDK/Models/Memberships.cs
+++ b/UCWASDK/UCWASDK/Models/Memberships.cs
@@ -16,12 +16,12 @@ namespace Microsoft.Skype.UCWA.Models
         internal InternalEmbedded Embedded { get; set; }
 
         [JsonIgnore]
-        public PresenceSubscriptionMembership PresenceSubscriptionMembership { get { return Embedded.presenceSubscriptionMembership; } }
+        public PresenceSubscriptionMembership[] PresenceSubscriptionMembership { get { return Embedded.presenceSubscriptionMembership; } }
 
         internal class InternalEmbedded
         {
             [JsonProperty("presenceSubscriptionMembership")]
-            internal PresenceSubscriptionMembership presenceSubscriptionMembership { get; set; }               
+            internal PresenceSubscriptionMembership[] presenceSubscriptionMembership { get; set; }
         }        
 
         public Task<PresenceSubscriptionMemberships> Update(string[] contactUris)


### PR DESCRIPTION
Unlike the name suggests, the `presenceSubscriptionMembership` property of `Memberships` is a JSON array of `PresenceSubscriptionMembership` rather than a single instance.

See [UCWA documentation](https://docs.microsoft.com/en-us/skype-sdk/ucwa/memberships_ref)
