### PR TITLE
Fix PresenceSubscriptionAdded Event

### DIFF
--- a/UCWASDK/UCWASDK/UCWAClient.cs
+++ b/UCWASDK/UCWASDK/UCWAClient.cs
@@ -1842,7 +1842,11 @@ namespace Microsoft.Skype.UCWA
                     await HandleDistributionGroupAddedEvent(people, cancellationToken);
                     break;
                 case "presenceSubscription":
-                    PresenceSubscriptionAdded?.Invoke(people.Embedded.PresenceSubscription);
+                    if (PresenceSubscriptionAdded != null)
+                    {
+                       var presenceSubscription = people.Embedded?.PresenceSubscription ?? await httpService.Get<PresenceSubscription>(people.Link.Href, cancellationToken);
+                       PresenceSubscriptionAdded.Invoke(presenceSubscription);
+                    }
                     break;
                 case "defaultGroup":
                 case "pinnedGroup":


### PR DESCRIPTION
When receiving a `PresenceSubscriptionAdded` event during our testing, it would never contain its `Embedded` part, hence causing a `NullReferenceException`.
This change null checks the `Embedded` and `PresenceSubscription` fields and GETs the missing `PresenceSubscription` if necessary, before firing the event.